### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix API token exposure over HTTP

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The `Collection` domain entity lacked `[MaxLength]` validation attributes on user-controlled text fields (`Title`, `Description`). If these objects are created or updated using the bulk API, or used as intermediary objects in operations like `SuggestCollectionForBookmarkAsync` that manipulate text sizes in buffers, exceptionally large inputs could lead to Denial of Service (DoS) due to excessive memory consumption.
 **Learning:** Shared domain entities used across various endpoints must maintain consistent data length limits. Relying entirely on downstream API validation introduces security gaps when processing or transforming this data locally (e.g., in ArrayPool allocations).
 **Prevention:** Apply `[MaxLength]` validation attributes to all text properties in domain models used for user input and data parsing to ensure safe bounds within the local application logic before passing downstream.
+
+## 2024-05-24 - [Enforce HTTPS]
+**Vulnerability:** API tokens could be transmitted in plaintext if HTTP was accidentally configured.
+**Learning:** We need layered checks (DataAnnotations and runtime validation) when handling sensitive tokens over external networks.
+**Prevention:** Always enforce HTTPS scheme validation both at configuration binding and right before HttpClient dispatch for third-party APIs.

--- a/src/Mcp/RaindropClientConfig.cs
+++ b/src/Mcp/RaindropClientConfig.cs
@@ -15,6 +15,12 @@ internal sealed class RaindropClientConfig
     {
         var opts = options.Value;
         BaseUri = new Uri(opts.BaseUrl);
+
+        if (BaseUri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new InvalidOperationException($"Insecure BaseUrl configured: '{opts.BaseUrl}'. HTTPS is strictly required to prevent API token exposure.");
+        }
+
         AuthorizationHeader = new AuthenticationHeaderValue("Bearer", opts.ApiToken);
     }
 }

--- a/src/Mcp/RaindropOptions.cs
+++ b/src/Mcp/RaindropOptions.cs
@@ -18,6 +18,6 @@ public class RaindropOptions
     /// </summary>
     [Required(AllowEmptyStrings = false)]
     [Url]
-    [RegularExpression(@"^https://.*", ErrorMessage = "BaseUrl must use HTTPS to prevent exposing the API token.")]
+    [RegularExpression(@"^(?i)https://.*", ErrorMessage = "BaseUrl must use HTTPS to prevent exposing the API token.")]
     public string BaseUrl { get; set; } = "https://api.raindrop.io/rest/v1";
 }

--- a/src/Mcp/RaindropOptions.cs
+++ b/src/Mcp/RaindropOptions.cs
@@ -18,5 +18,6 @@ public class RaindropOptions
     /// </summary>
     [Required(AllowEmptyStrings = false)]
     [Url]
+    [RegularExpression(@"^https://.*", ErrorMessage = "BaseUrl must use HTTPS to prevent exposing the API token.")]
     public string BaseUrl { get; set; } = "https://api.raindrop.io/rest/v1";
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: API tokens could be transmitted in plaintext if the user accidentally configured the `BaseUrl` to use `http://` instead of `https://`.
🎯 Impact: An attacker intercepting network traffic could steal the user's Raindrop API token, gaining full access to their bookmarks.
🔧 Fix: Implemented layered security validation. Added a `[RegularExpression]` attribute to `RaindropOptions.BaseUrl` to enforce HTTPS at configuration time, and a runtime check in `RaindropClientConfig` that throws an `InvalidOperationException` if the scheme is not HTTPS before the HTTP client is initialized.
✅ Verification: Ensure tests pass and attempting to use `http://api.raindrop.io` throws an error.

---
*PR created automatically by Jules for task [4447323896825813754](https://jules.google.com/task/4447323896825813754) started by @g1ddy*