### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information leakage via unhandled exceptions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,7 @@
 **Vulnerability:** API tokens could be transmitted in plaintext if HTTP was accidentally configured.
 **Learning:** We need layered checks (DataAnnotations and runtime validation) when handling sensitive tokens over external networks.
 **Prevention:** Always enforce HTTPS scheme validation both at configuration binding and right before HttpClient dispatch for third-party APIs.
+## 2024-03-24 - [Information Leakage via Unhandled Exceptions]
+**Vulnerability:** The application was exposing internal framework details (stack traces) to stderr when starting without required configurations (like the Raindrop API token).
+**Learning:** By default, .NET Generic Host allows configuration validation exceptions to crash the application, resulting in a verbose, generic stack trace that leaks internal code paths and framework versions.
+**Prevention:** Implement fail-fast configuration checks early in the application startup pipeline (Program.cs) before the main Host run loop. Catch OptionsValidationException to provide clean, generic error messages and exit gracefully (Environment.Exit), preventing stack trace leaks.

--- a/src/Mcp/Program.cs
+++ b/src/Mcp/Program.cs
@@ -37,6 +37,18 @@ builder.Services
 
 var app = builder.Build();
 
+// Fail-fast configuration check
+try
+{
+    _ = app.Services.GetRequiredService<Microsoft.Extensions.Options.IOptions<RaindropOptions>>().Value;
+}
+catch (Microsoft.Extensions.Options.OptionsValidationException ex)
+{
+    Console.Error.WriteLine($"\nError: Configuration validation failed. {ex.Message}");
+    Console.Error.WriteLine("Please ensure the 'Raindrop:ApiToken' environment variable or configuration value is set.");
+    Environment.Exit(1);
+}
+
 // app.MapMcp();
 
 await app.RunAsync();

--- a/src/Mcp/Program.cs
+++ b/src/Mcp/Program.cs
@@ -45,7 +45,7 @@ try
 catch (Microsoft.Extensions.Options.OptionsValidationException ex)
 {
     Console.Error.WriteLine($"\nError: Configuration validation failed. {ex.Message}");
-    Console.Error.WriteLine("Please ensure the 'Raindrop:ApiToken' environment variable or configuration value is set.");
+    app.Dispose();
     Environment.Exit(1);
 }
 


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The application exposed internal framework details (stack traces) to stderr when starting without required configurations (like the Raindrop API token).
🎯 **Impact**: Potential information leakage allowing an attacker to map internal code paths, directory structures, and exact framework versions from raw stack traces emitted to standard output.
🔧 **Fix**: Implemented a fail-fast configuration check early in the application startup pipeline (`Program.cs`) before the main Host run loop. It manually catches `OptionsValidationException` to provide a clean, generic error message and exits gracefully (`Environment.Exit(1)`), preventing the stack trace leak.
✅ **Verification**: Run `dotnet run` locally without setting `Raindrop:ApiToken`. The application exits cleanly with a helpful message without dumping the stack.

---
*PR created automatically by Jules for task [16623118421778070752](https://jules.google.com/task/16623118421778070752) started by @g1ddy*