### PR TITLE
⚡ Bolt: [performance improvement] Caching for Available Filters

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Zero-allocation Cache Key Hashing
 **Learning:** Computing cache keys by hashing strings (e.g., API tokens) using `Encoding.UTF8.GetBytes()` followed by `SHA256.HashData(byte[])` causes unnecessary heap allocations for the byte array on every cache access.
 **Action:** Use `stackalloc byte[]` for small strings combined with `ArrayPool<byte>.Shared.Rent` for larger ones, and pass `Span<byte>` to `SHA256.HashData`. This reduces allocations per hash by ~50% (from 312B to 152B for a typical token), allocating only the final hex string.
+
+## 2024-05-18 - [Caching Parameterized Queries]
+**Learning:** When adding caching for methods with multiple parameters (like `GetAvailableFiltersAsync`), the parameters must be incorporated into the cache key to prevent cross-contamination where distinct queries return identical cached results.
+**Action:** Always construct a composite cache key encompassing all relevant method parameters for endpoints that take query filters.

--- a/baseline_benchmark.log
+++ b/baseline_benchmark.log
@@ -1,0 +1,142 @@
+// Validating benchmarks:
+// ***** BenchmarkRunner: Start   *****
+// ***** Found 1 benchmark(s) in total *****
+// ***** Building 1 exe(s) in Parallel: Start   *****
+// start dotnet  restore --nodeReuse:false /p:UseSharedCompilation=false /p:Deterministic=true /p:Optimize=true /p:ArtifactsPath="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/" /p:OutDir="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/bin/Release/net10.0/" /p:OutputPath="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/bin/Release/net10.0/" /p:PublishDir="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/publish/" in /app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1
+// command took 3.04 sec and exited with 0
+// start dotnet  build -c Release --no-restore --nodeReuse:false /p:UseSharedCompilation=false /p:Deterministic=true /p:Optimize=true /p:ArtifactsPath="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/" /p:OutDir="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/bin/Release/net10.0/" /p:OutputPath="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/bin/Release/net10.0/" /p:PublishDir="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/publish/" --output "/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/bin/Release/net10.0/" in /app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1
+// command took 20.71 sec and exited with 0
+// ***** Done, took 00:00:23 (23.87 sec)   *****
+// Found 1 benchmarks:
+//   FiltersToolsBenchmark.GetAvailableFilters: DefaultJob
+
+// **************************
+// Benchmark: FiltersToolsBenchmark.GetAvailableFilters: DefaultJob
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet Mcp.Benchmarks-DefaultJob-1.dll --anonymousPipes 144 145 --benchmarkName Mcp.Benchmarks.FiltersToolsBenchmark.GetAvailableFilters --job Default --benchmarkId 0 in /app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.15.8
+// Runtime=.NET 10.0.4 (10.0.4, 10.0.426.12010), X64 RyuJIT x86-64-v3
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2+BMI1+BMI2+F16C+FMA+LZCNT+MOVBE,AVX,SSE3+SSSE3+SSE4.1+SSE4.2+POPCNT,X86Base+SSE+SSE2,AES+PCLMUL VectorSize=256
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 326554.00 ns, 326.5540 us/op
+WorkloadJitting  1: 1 op, 64085317.00 ns, 64.0853 ms/op
+
+WorkloadPilot    1: 2 op, 104947377.00 ns, 52.4737 ms/op
+WorkloadPilot    2: 3 op, 155236931.00 ns, 51.7456 ms/op
+WorkloadPilot    3: 4 op, 206383084.00 ns, 51.5958 ms/op
+WorkloadPilot    4: 5 op, 257077911.00 ns, 51.4156 ms/op
+WorkloadPilot    5: 6 op, 308193693.00 ns, 51.3656 ms/op
+WorkloadPilot    6: 7 op, 362907293.00 ns, 51.8439 ms/op
+WorkloadPilot    7: 8 op, 417886991.00 ns, 52.2359 ms/op
+WorkloadPilot    8: 9 op, 468140959.00 ns, 52.0157 ms/op
+WorkloadPilot    9: 10 op, 516783239.00 ns, 51.6783 ms/op
+
+WorkloadWarmup   1: 10 op, 519347367.00 ns, 51.9347 ms/op
+WorkloadWarmup   2: 10 op, 519169231.00 ns, 51.9169 ms/op
+WorkloadWarmup   3: 10 op, 519908430.00 ns, 51.9908 ms/op
+WorkloadWarmup   4: 10 op, 516993153.00 ns, 51.6993 ms/op
+WorkloadWarmup   5: 10 op, 519158695.00 ns, 51.9159 ms/op
+WorkloadWarmup   6: 10 op, 520944029.00 ns, 52.0944 ms/op
+WorkloadWarmup   7: 10 op, 516376848.00 ns, 51.6377 ms/op
+
+// BeforeActualRun
+WorkloadActual   1: 10 op, 518598629.00 ns, 51.8599 ms/op
+WorkloadActual   2: 10 op, 516901218.00 ns, 51.6901 ms/op
+WorkloadActual   3: 10 op, 521022323.00 ns, 52.1022 ms/op
+WorkloadActual   4: 10 op, 520851421.00 ns, 52.0851 ms/op
+WorkloadActual   5: 10 op, 519043910.00 ns, 51.9044 ms/op
+WorkloadActual   6: 10 op, 519069468.00 ns, 51.9069 ms/op
+WorkloadActual   7: 10 op, 521032451.00 ns, 52.1032 ms/op
+WorkloadActual   8: 10 op, 521181820.00 ns, 52.1182 ms/op
+WorkloadActual   9: 10 op, 516456581.00 ns, 51.6457 ms/op
+WorkloadActual  10: 10 op, 516954697.00 ns, 51.6955 ms/op
+WorkloadActual  11: 10 op, 516645450.00 ns, 51.6645 ms/op
+WorkloadActual  12: 10 op, 518780579.00 ns, 51.8781 ms/op
+WorkloadActual  13: 10 op, 516919238.00 ns, 51.6919 ms/op
+WorkloadActual  14: 10 op, 516764898.00 ns, 51.6765 ms/op
+WorkloadActual  15: 10 op, 517252752.00 ns, 51.7253 ms/op
+
+// AfterActualRun
+WorkloadResult   1: 10 op, 518598629.00 ns, 51.8599 ms/op
+WorkloadResult   2: 10 op, 516901218.00 ns, 51.6901 ms/op
+WorkloadResult   3: 10 op, 521022323.00 ns, 52.1022 ms/op
+WorkloadResult   4: 10 op, 520851421.00 ns, 52.0851 ms/op
+WorkloadResult   5: 10 op, 519043910.00 ns, 51.9044 ms/op
+WorkloadResult   6: 10 op, 519069468.00 ns, 51.9069 ms/op
+WorkloadResult   7: 10 op, 521032451.00 ns, 52.1032 ms/op
+WorkloadResult   8: 10 op, 521181820.00 ns, 52.1182 ms/op
+WorkloadResult   9: 10 op, 516456581.00 ns, 51.6457 ms/op
+WorkloadResult  10: 10 op, 516954697.00 ns, 51.6955 ms/op
+WorkloadResult  11: 10 op, 516645450.00 ns, 51.6645 ms/op
+WorkloadResult  12: 10 op, 518780579.00 ns, 51.8781 ms/op
+WorkloadResult  13: 10 op, 516919238.00 ns, 51.6919 ms/op
+WorkloadResult  14: 10 op, 516764898.00 ns, 51.6765 ms/op
+WorkloadResult  15: 10 op, 517252752.00 ns, 51.7253 ms/op
+// GC:  0 0 0 12432 10
+// Threading:  10 0 10
+
+// AfterAll
+// Benchmark Process 12475 has exited with code 0.
+
+Mean = 51.850 ms, StdErr = 0.047 ms (0.09%), N = 15, StdDev = 0.181 ms
+Min = 51.646 ms, Q1 = 51.691 ms, Median = 51.860 ms, Q3 = 51.996 ms, Max = 52.118 ms
+IQR = 0.305 ms, LowerFence = 51.233 ms, UpperFence = 52.454 ms
+ConfidenceInterval = [51.656 ms; 52.043 ms] (CI 99.9%), Margin = 0.193 ms (0.37% of Mean)
+Skewness = 0.35, Kurtosis = 1.39, MValue = 2
+
+// ** Remained 0 (0.0 %) benchmark(s) to run. Estimated finish 2026-04-20 5:56 (0h 0m from now) **
+// ***** BenchmarkRunner: Finish  *****
+
+// * Export *
+  BenchmarkDotNet.Artifacts/results/Mcp.Benchmarks.FiltersToolsBenchmark-report.csv
+  BenchmarkDotNet.Artifacts/results/Mcp.Benchmarks.FiltersToolsBenchmark-report-github.md
+  BenchmarkDotNet.Artifacts/results/Mcp.Benchmarks.FiltersToolsBenchmark-report.html
+
+// * Detailed results *
+FiltersToolsBenchmark.GetAvailableFilters: DefaultJob
+Runtime = .NET 10.0.4 (10.0.4, 10.0.426.12010), X64 RyuJIT x86-64-v3; GC = Concurrent Workstation
+Mean = 51.850 ms, StdErr = 0.047 ms (0.09%), N = 15, StdDev = 0.181 ms
+Min = 51.646 ms, Q1 = 51.691 ms, Median = 51.860 ms, Q3 = 51.996 ms, Max = 52.118 ms
+IQR = 0.305 ms, LowerFence = 51.233 ms, UpperFence = 52.454 ms
+ConfidenceInterval = [51.656 ms; 52.043 ms] (CI 99.9%), Margin = 0.193 ms (0.37% of Mean)
+Skewness = 0.35, Kurtosis = 1.39, MValue = 2
+-------------------- Histogram --------------------
+[51.549 ms ; 52.214 ms) | @@@@@@@@@@@@@@@
+---------------------------------------------------
+
+// * Summary *
+
+BenchmarkDotNet v0.15.8, Linux Ubuntu 24.04.4 LTS (Noble Numbat)
+Intel Xeon Processor 2.30GHz, 1 CPU, 4 logical and 4 physical cores
+.NET SDK 10.0.104
+  [Host]     : .NET 10.0.4 (10.0.4, 10.0.426.12010), X64 RyuJIT x86-64-v3
+  DefaultJob : .NET 10.0.4 (10.0.4, 10.0.426.12010), X64 RyuJIT x86-64-v3
+
+
+| Method              | Mean     | Error    | StdDev   | Allocated |
+|-------------------- |---------:|---------:|---------:|----------:|
+| GetAvailableFilters | 51.85 ms | 0.193 ms | 0.181 ms |   1.21 KB |
+
+// * Legends *
+  Mean      : Arithmetic mean of all measurements
+  Error     : Half of 99.9% confidence interval
+  StdDev    : Standard deviation of all measurements
+  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
+  1 ms      : 1 Millisecond (0.001 sec)
+
+// * Diagnostic Output - MemoryDiagnoser *
+
+
+// ***** BenchmarkRunner: End *****
+Run time: 00:00:15 (15.39 sec), executed benchmarks: 1
+
+Global total time: 00:00:39 (39.46 sec), executed benchmarks: 1
+// * Artifacts cleanup *
+Artifacts cleanup is finished

--- a/optimized_benchmark.log
+++ b/optimized_benchmark.log
@@ -1,0 +1,166 @@
+// Validating benchmarks:
+// ***** BenchmarkRunner: Start   *****
+// ***** Found 1 benchmark(s) in total *****
+// ***** Building 1 exe(s) in Parallel: Start   *****
+// start dotnet  restore --nodeReuse:false /p:UseSharedCompilation=false /p:Deterministic=true /p:Optimize=true /p:ArtifactsPath="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/" /p:OutDir="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/bin/Release/net10.0/" /p:OutputPath="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/bin/Release/net10.0/" /p:PublishDir="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/publish/" in /app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1
+// command took 2.45 sec and exited with 0
+// start dotnet  build -c Release --no-restore --nodeReuse:false /p:UseSharedCompilation=false /p:Deterministic=true /p:Optimize=true /p:ArtifactsPath="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/" /p:OutDir="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/bin/Release/net10.0/" /p:OutputPath="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/bin/Release/net10.0/" /p:PublishDir="/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/publish/" --output "/app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/bin/Release/net10.0/" in /app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1
+// command took 18.36 sec and exited with 0
+// ***** Done, took 00:00:20 (20.89 sec)   *****
+// Found 1 benchmarks:
+//   FiltersToolsBenchmark.GetAvailableFilters: DefaultJob
+
+// **************************
+// Benchmark: FiltersToolsBenchmark.GetAvailableFilters: DefaultJob
+// *** Execute ***
+// Launch: 1 / 1
+// Execute: dotnet Mcp.Benchmarks-DefaultJob-1.dll --anonymousPipes 144 145 --benchmarkName Mcp.Benchmarks.FiltersToolsBenchmark.GetAvailableFilters --job Default --benchmarkId 0 in /app/tests/Mcp.Benchmarks/bin/Release/net10.0/Mcp.Benchmarks-DefaultJob-1/bin/Release/net10.0
+// Failed to set up high priority (Permission denied). In order to run benchmarks with high priority, make sure you have the right permissions.
+// BeforeAnythingElse
+
+// Benchmark Process Environment Information:
+// BenchmarkDotNet v0.15.8
+// Runtime=.NET 10.0.4 (10.0.4, 10.0.426.12010), X64 RyuJIT x86-64-v3
+// GC=Concurrent Workstation
+// HardwareIntrinsics=AVX2+BMI1+BMI2+F16C+FMA+LZCNT+MOVBE,AVX,SSE3+SSSE3+SSE4.1+SSE4.2+POPCNT,X86Base+SSE+SSE2,AES+PCLMUL VectorSize=256
+// Job: DefaultJob
+
+OverheadJitting  1: 1 op, 261880.00 ns, 261.8800 us/op
+WorkloadJitting  1: 1 op, 79173760.00 ns, 79.1738 ms/op
+
+WorkloadPilot    1: 2 op, 453778.00 ns, 226.8890 us/op
+WorkloadPilot    2: 3 op, 35595.00 ns, 11.8650 us/op
+WorkloadPilot    3: 4 op, 34476.00 ns, 8.6190 us/op
+WorkloadPilot    4: 5 op, 34290.00 ns, 6.8580 us/op
+WorkloadPilot    5: 6 op, 35403.00 ns, 5.9005 us/op
+WorkloadPilot    6: 7 op, 37945.00 ns, 5.4207 us/op
+WorkloadPilot    7: 8 op, 56139.00 ns, 7.0174 us/op
+WorkloadPilot    8: 9 op, 64761.00 ns, 7.1957 us/op
+WorkloadPilot    9: 10 op, 72965.00 ns, 7.2965 us/op
+WorkloadPilot   10: 11 op, 106014.00 ns, 9.6376 us/op
+WorkloadPilot   11: 12 op, 71150.00 ns, 5.9292 us/op
+WorkloadPilot   12: 13 op, 74740.00 ns, 5.7492 us/op
+WorkloadPilot   13: 14 op, 75886.00 ns, 5.4204 us/op
+WorkloadPilot   14: 15 op, 84628.00 ns, 5.6419 us/op
+WorkloadPilot   15: 16 op, 119870.00 ns, 7.4919 us/op
+WorkloadPilot   16: 32 op, 126834.00 ns, 3.9636 us/op
+WorkloadPilot   17: 64 op, 226727.00 ns, 3.5426 us/op
+WorkloadPilot   18: 128 op, 474908.00 ns, 3.7102 us/op
+WorkloadPilot   19: 256 op, 846123.00 ns, 3.3052 us/op
+WorkloadPilot   20: 512 op, 1889601.00 ns, 3.6906 us/op
+WorkloadPilot   21: 1024 op, 3482622.00 ns, 3.4010 us/op
+WorkloadPilot   22: 2048 op, 6714103.00 ns, 3.2784 us/op
+WorkloadPilot   23: 4096 op, 13124519.00 ns, 3.2042 us/op
+WorkloadPilot   24: 8192 op, 25452746.00 ns, 3.1070 us/op
+WorkloadPilot   25: 16384 op, 51125070.00 ns, 3.1204 us/op
+WorkloadPilot   26: 32768 op, 112118366.00 ns, 3.4216 us/op
+WorkloadPilot   27: 65536 op, 178823270.00 ns, 2.7286 us/op
+WorkloadPilot   28: 131072 op, 203501979.00 ns, 1.5526 us/op
+WorkloadPilot   29: 262144 op, 411268141.00 ns, 1.5689 us/op
+WorkloadPilot   30: 524288 op, 827246164.00 ns, 1.5778 us/op
+
+WorkloadWarmup   1: 524288 op, 815201070.00 ns, 1.5549 us/op
+WorkloadWarmup   2: 524288 op, 823598814.00 ns, 1.5709 us/op
+WorkloadWarmup   3: 524288 op, 831132895.00 ns, 1.5853 us/op
+WorkloadWarmup   4: 524288 op, 843774141.00 ns, 1.6094 us/op
+WorkloadWarmup   5: 524288 op, 827607562.00 ns, 1.5785 us/op
+WorkloadWarmup   6: 524288 op, 829069812.00 ns, 1.5813 us/op
+WorkloadWarmup   7: 524288 op, 823954831.00 ns, 1.5716 us/op
+
+// BeforeActualRun
+WorkloadActual   1: 524288 op, 823839891.00 ns, 1.5713 us/op
+WorkloadActual   2: 524288 op, 832265104.00 ns, 1.5874 us/op
+WorkloadActual   3: 524288 op, 926228937.00 ns, 1.7666 us/op
+WorkloadActual   4: 524288 op, 843090035.00 ns, 1.6081 us/op
+WorkloadActual   5: 524288 op, 826084822.00 ns, 1.5756 us/op
+WorkloadActual   6: 524288 op, 823495259.00 ns, 1.5707 us/op
+WorkloadActual   7: 524288 op, 826478002.00 ns, 1.5764 us/op
+WorkloadActual   8: 524288 op, 828876328.00 ns, 1.5810 us/op
+WorkloadActual   9: 524288 op, 818178847.00 ns, 1.5606 us/op
+WorkloadActual  10: 524288 op, 828789689.00 ns, 1.5808 us/op
+WorkloadActual  11: 524288 op, 821861110.00 ns, 1.5676 us/op
+WorkloadActual  12: 524288 op, 819429946.00 ns, 1.5629 us/op
+WorkloadActual  13: 524288 op, 823356922.00 ns, 1.5704 us/op
+WorkloadActual  14: 524288 op, 830002402.00 ns, 1.5831 us/op
+WorkloadActual  15: 524288 op, 825429180.00 ns, 1.5744 us/op
+
+// AfterActualRun
+WorkloadResult   1: 524288 op, 823839891.00 ns, 1.5713 us/op
+WorkloadResult   2: 524288 op, 832265104.00 ns, 1.5874 us/op
+WorkloadResult   3: 524288 op, 826084822.00 ns, 1.5756 us/op
+WorkloadResult   4: 524288 op, 823495259.00 ns, 1.5707 us/op
+WorkloadResult   5: 524288 op, 826478002.00 ns, 1.5764 us/op
+WorkloadResult   6: 524288 op, 828876328.00 ns, 1.5810 us/op
+WorkloadResult   7: 524288 op, 818178847.00 ns, 1.5606 us/op
+WorkloadResult   8: 524288 op, 828789689.00 ns, 1.5808 us/op
+WorkloadResult   9: 524288 op, 821861110.00 ns, 1.5676 us/op
+WorkloadResult  10: 524288 op, 819429946.00 ns, 1.5629 us/op
+WorkloadResult  11: 524288 op, 823356922.00 ns, 1.5704 us/op
+WorkloadResult  12: 524288 op, 830002402.00 ns, 1.5831 us/op
+WorkloadResult  13: 524288 op, 825429180.00 ns, 1.5744 us/op
+// GC:  12 0 0 297795584 524288
+// Threading:  0 0 524288
+
+// AfterAll
+// Benchmark Process 61276 has exited with code 0.
+
+Mean = 1.574 us, StdErr = 0.002 us (0.14%), N = 13, StdDev = 0.008 us
+Min = 1.561 us, Q1 = 1.570 us, Median = 1.574 us, Q3 = 1.581 us, Max = 1.587 us
+IQR = 0.010 us, LowerFence = 1.555 us, UpperFence = 1.596 us
+ConfidenceInterval = [1.565 us; 1.583 us] (CI 99.9%), Margin = 0.009 us (0.60% of Mean)
+Skewness = -0.05, Kurtosis = 1.89, MValue = 2
+
+// ** Remained 0 (0.0 %) benchmark(s) to run. Estimated finish 2026-04-20 6:00 (0h 0m from now) **
+// ***** BenchmarkRunner: Finish  *****
+
+// * Export *
+  BenchmarkDotNet.Artifacts/results/Mcp.Benchmarks.FiltersToolsBenchmark-report.csv
+  BenchmarkDotNet.Artifacts/results/Mcp.Benchmarks.FiltersToolsBenchmark-report-github.md
+  BenchmarkDotNet.Artifacts/results/Mcp.Benchmarks.FiltersToolsBenchmark-report.html
+
+// * Detailed results *
+FiltersToolsBenchmark.GetAvailableFilters: DefaultJob
+Runtime = .NET 10.0.4 (10.0.4, 10.0.426.12010), X64 RyuJIT x86-64-v3; GC = Concurrent Workstation
+Mean = 1.574 us, StdErr = 0.002 us (0.14%), N = 13, StdDev = 0.008 us
+Min = 1.561 us, Q1 = 1.570 us, Median = 1.574 us, Q3 = 1.581 us, Max = 1.587 us
+IQR = 0.010 us, LowerFence = 1.555 us, UpperFence = 1.596 us
+ConfidenceInterval = [1.565 us; 1.583 us] (CI 99.9%), Margin = 0.009 us (0.60% of Mean)
+Skewness = -0.05, Kurtosis = 1.89, MValue = 2
+-------------------- Histogram --------------------
+[1.558 us ; 1.589 us) | @@@@@@@@@@@@@
+---------------------------------------------------
+
+// * Summary *
+
+BenchmarkDotNet v0.15.8, Linux Ubuntu 24.04.4 LTS (Noble Numbat)
+Intel Xeon Processor 2.30GHz, 1 CPU, 4 logical and 4 physical cores
+.NET SDK 10.0.104
+  [Host]     : .NET 10.0.4 (10.0.4, 10.0.426.12010), X64 RyuJIT x86-64-v3
+  DefaultJob : .NET 10.0.4 (10.0.4, 10.0.426.12010), X64 RyuJIT x86-64-v3
+
+
+| Method              | Mean     | Error     | StdDev    | Gen0   | Allocated |
+|-------------------- |---------:|----------:|----------:|-------:|----------:|
+| GetAvailableFilters | 1.574 us | 0.0094 us | 0.0079 us | 0.0229 |     568 B |
+
+// * Hints *
+Outliers
+  FiltersToolsBenchmark.GetAvailableFilters: Default -> 2 outliers were removed (1.61 us, 1.77 us)
+
+// * Legends *
+  Mean      : Arithmetic mean of all measurements
+  Error     : Half of 99.9% confidence interval
+  StdDev    : Standard deviation of all measurements
+  Gen0      : GC Generation 0 collects per 1000 operations
+  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
+  1 us      : 1 Microsecond (0.000001 sec)
+
+// * Diagnostic Output - MemoryDiagnoser *
+
+
+// ***** BenchmarkRunner: End *****
+Run time: 00:00:21 (21.7 sec), executed benchmarks: 1
+
+Global total time: 00:00:42 (42.76 sec), executed benchmarks: 1
+// * Artifacts cleanup *
+Artifacts cleanup is finished

--- a/src/Mcp/Common/IRaindropCacheService.cs
+++ b/src/Mcp/Common/IRaindropCacheService.cs
@@ -18,6 +18,17 @@ public interface IRaindropCacheService : IDisposable
         CancellationToken cancellationToken);
 
     /// <summary>
+    /// Gets the cached filters or fetches them using the provided function.
+    /// </summary>
+    Task<Mcp.Filters.AvailableFilters> GetFiltersAsync(
+        string key,
+        long collectionId,
+        string? tagsSort,
+        string? search,
+        Func<CancellationToken, Task<Mcp.Filters.AvailableFilters>> fetchFunc,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Gets the cached tags list or fetches it using the provided function.
     /// </summary>
     Task<ItemsResponse<TagInfo>> GetTagsAsync(
@@ -52,4 +63,9 @@ public interface IRaindropCacheService : IDisposable
     /// Invalidates user info cache for a specific user.
     /// </summary>
     Task InvalidateUserInfoAsync(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Invalidates filters cache for a specific user.
+    /// </summary>
+    Task InvalidateFiltersAsync(string key, CancellationToken cancellationToken = default);
 }

--- a/src/Mcp/Common/RaindropCacheService.cs
+++ b/src/Mcp/Common/RaindropCacheService.cs
@@ -28,6 +28,9 @@ public class RaindropCacheService : IRaindropCacheService
     private readonly ConcurrentDictionary<string, CacheEntry<ItemResponse<UserInfo>>> _userInfoCache = new();
     private readonly SemaphoreSlim _userInfoLock = new(1, 1);
 
+    private readonly ConcurrentDictionary<string, CacheEntry<Mcp.Filters.AvailableFilters>> _filtersCache = new();
+    private readonly SemaphoreSlim _filtersLock = new(1, 1);
+
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
 
     /// <summary>
@@ -55,6 +58,7 @@ public class RaindropCacheService : IRaindropCacheService
             if (response is ItemsResponse<Collection> c) isSuccess = c.Result && c.Items != null;
             else if (response is ItemsResponse<TagInfo> t) isSuccess = t.Result && t.Items != null;
             else if (response is ItemResponse<UserInfo> u) isSuccess = u.Result && u.Item != null;
+            else if (response is Mcp.Filters.AvailableFilters f) isSuccess = f.Result;
 
             if (isSuccess)
             {
@@ -93,6 +97,8 @@ public class RaindropCacheService : IRaindropCacheService
             return (T)(object)(t with { Items = [.. t.Items] });
         if (response is ItemResponse<UserInfo> u)
             return (T)(object)(u with { }); // Shallow copy is enough for records if properties are immutable
+        if (response is Mcp.Filters.AvailableFilters f)
+            return (T)(object)(f with { Tags = f.Tags != null ? [.. f.Tags] : null, Types = f.Types != null ? [.. f.Types] : null });
 
         return response;
     }
@@ -136,6 +142,20 @@ public class RaindropCacheService : IRaindropCacheService
         CancellationToken cancellationToken)
         => GetOrFetchAsync(ComputeCacheKey(key), _collectionsCache, _collectionsLock, fetchFunc, cancellationToken);
 
+    public Task<Mcp.Filters.AvailableFilters> GetFiltersAsync(
+        string key,
+        long collectionId,
+        string? tagsSort,
+        string? search,
+        Func<CancellationToken, Task<Mcp.Filters.AvailableFilters>> fetchFunc,
+        CancellationToken cancellationToken)
+    {
+        var hashedKey = ComputeCacheKey(key);
+        // Combine with query parameters to create a unique cache key per user + query
+        var cacheKey = $"{hashedKey}_{collectionId}_{tagsSort}_{search}";
+        return GetOrFetchAsync(cacheKey, _filtersCache, _filtersLock, fetchFunc, cancellationToken);
+    }
+
     /// <summary>
     /// Gets the cached tags list or fetches it using the provided function.
     /// </summary>
@@ -164,6 +184,16 @@ public class RaindropCacheService : IRaindropCacheService
         _collectionsCache.TryRemove(hashedKey, out _);
         _tagsCache.TryRemove(hashedKey, out _);
         _userInfoCache.TryRemove(hashedKey, out _);
+
+        // Remove all filter caches that start with the user's hashed key
+        foreach (var cacheKey in _filtersCache.Keys)
+        {
+            if (cacheKey.StartsWith(hashedKey))
+            {
+                _filtersCache.TryRemove(cacheKey, out _);
+            }
+        }
+
         return Task.CompletedTask;
     }
 
@@ -185,11 +215,28 @@ public class RaindropCacheService : IRaindropCacheService
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Invalidates filters cache for a specific user.
+    /// </summary>
+    public Task InvalidateFiltersAsync(string key, CancellationToken cancellationToken = default)
+    {
+        var hashedKey = ComputeCacheKey(key);
+        foreach (var cacheKey in _filtersCache.Keys)
+        {
+            if (cacheKey.StartsWith(hashedKey))
+            {
+                _filtersCache.TryRemove(cacheKey, out _);
+            }
+        }
+        return Task.CompletedTask;
+    }
+
     public void Dispose()
     {
         _collectionsLock.Dispose();
         _tagsLock.Dispose();
         _userInfoLock.Dispose();
+        _filtersLock.Dispose();
         GC.SuppressFinalize(this);
     }
 }

--- a/src/Mcp/Filters/FiltersTools.cs
+++ b/src/Mcp/Filters/FiltersTools.cs
@@ -1,12 +1,16 @@
 using System.ComponentModel;
+using Microsoft.Extensions.Options;
 using ModelContextProtocol.Server;
 using Mcp.Common;
 
 namespace Mcp.Filters;
 
 [McpServerToolType]
-public class FiltersTools(IFiltersApi api) : RaindropToolBase<IFiltersApi>(api)
+public class FiltersTools(IFiltersApi api, IRaindropCacheService cacheService, IOptions<RaindropOptions> options) : RaindropToolBase<IFiltersApi>(api)
 {
+    private readonly IRaindropCacheService _cacheService = cacheService;
+    private readonly string _cacheKey = options.Value.ApiToken;
+
     [McpServerTool(Destructive = false, Idempotent = true, ReadOnly = true,
         Title = "Get Available Filters"),
      Description("Retrieves available filters for a specific collection or all bookmarks.")]
@@ -19,6 +23,12 @@ public class FiltersTools(IFiltersApi api) : RaindropToolBase<IFiltersApi>(api)
         if (tagsSort is not null && tagsSort != "-count" && tagsSort != "_id")
             throw new ArgumentOutOfRangeException(nameof(tagsSort), tagsSort, "Valid values are '-count' or '_id'.");
 
-        return Api.GetAsync(collectionId, tagsSort, search, cancellationToken);
+        return _cacheService.GetFiltersAsync(
+            _cacheKey,
+            collectionId,
+            tagsSort,
+            search,
+            ct => Api.GetAsync(collectionId, tagsSort, search, ct),
+            cancellationToken);
     }
 }

--- a/tests/Mcp.Benchmarks/FiltersToolsBenchmark.cs
+++ b/tests/Mcp.Benchmarks/FiltersToolsBenchmark.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+using Mcp.Filters;
+using Mcp.Common;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace Mcp.Benchmarks;
+
+[MemoryDiagnoser]
+public class FiltersToolsBenchmark
+{
+    private FiltersTools _tools = null!;
+    private Mock<IFiltersApi> _filtersApiMock = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _filtersApiMock = new Mock<IFiltersApi>();
+
+        // Mock GetAsync with a slight delay to simulate network latency
+        _filtersApiMock.Setup(x => x.GetAsync(It.IsAny<long>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(async (long id, string? sort, string? search, CancellationToken ct) => {
+                await Task.Delay(50, ct);
+                return new AvailableFilters { Result = true };
+            });
+
+        var options = Options.Create(new RaindropOptions { ApiToken = "benchmark-token" });
+        _tools = new FiltersTools(_filtersApiMock.Object, new RaindropCacheService(), options);
+    }
+
+    [Benchmark]
+    public async Task GetAvailableFilters()
+    {
+        await _tools.GetAvailableFiltersAsync(0, null, null, CancellationToken.None);
+    }
+}

--- a/tests/Mcp.Tests/Caching/FiltersToolsCacheTests.cs
+++ b/tests/Mcp.Tests/Caching/FiltersToolsCacheTests.cs
@@ -1,0 +1,49 @@
+using Mcp.Filters;
+using Mcp.Common;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Mcp.Tests.Caching;
+
+public class FiltersToolsCacheTests
+{
+    [Fact]
+    public async Task GetAvailableFiltersAsync_UsesCacheAndDifferentiatesByParams()
+    {
+        // Arrange
+        var mockApi = new Mock<IFiltersApi>();
+        var cacheService = new RaindropCacheService();
+        var options = Options.Create(new RaindropOptions { ApiToken = "test-token" });
+
+        var tools = new FiltersTools(mockApi.Object, cacheService, options);
+
+        mockApi.Setup(x => x.GetAsync(It.IsAny<long>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((long id, string? sort, string? search, CancellationToken ct) => new AvailableFilters { Result = true, Tags = new List<FilterEntry> { new() { Id = $"{id}-{sort}-{search}" } } });
+
+        // Act & Assert 1: First call, hits API
+        var result1 = await tools.GetAvailableFiltersAsync(1, "-count", "test", CancellationToken.None);
+        Assert.True(result1.Result);
+        mockApi.Verify(x => x.GetAsync(1, "-count", "test", It.IsAny<CancellationToken>()), Times.Once);
+
+        // Act & Assert 2: Second call with SAME params, hits cache (API count remains 1)
+        var result2 = await tools.GetAvailableFiltersAsync(1, "-count", "test", CancellationToken.None);
+        Assert.True(result2.Result);
+        mockApi.Verify(x => x.GetAsync(1, "-count", "test", It.IsAny<CancellationToken>()), Times.Once);
+
+        // Act & Assert 3: Call with DIFFERENT collectionId, hits API (API count becomes 2)
+        var result3 = await tools.GetAvailableFiltersAsync(2, "-count", "test", CancellationToken.None);
+        Assert.True(result3.Result);
+        mockApi.Verify(x => x.GetAsync(2, "-count", "test", It.IsAny<CancellationToken>()), Times.Once);
+
+        // Act & Assert 4: Call with DIFFERENT tagsSort, hits API (API count becomes 3)
+        var result4 = await tools.GetAvailableFiltersAsync(1, "_id", "test", CancellationToken.None);
+        Assert.True(result4.Result);
+        mockApi.Verify(x => x.GetAsync(1, "_id", "test", It.IsAny<CancellationToken>()), Times.Once);
+
+        // Act & Assert 5: Call with DIFFERENT search, hits API (API count becomes 4)
+        var result5 = await tools.GetAvailableFiltersAsync(1, "-count", "different", CancellationToken.None);
+        Assert.True(result5.Result);
+        mockApi.Verify(x => x.GetAsync(1, "-count", "different", It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
💡 **What:** Added caching functionality to the `GetAvailableFiltersAsync` method in `FiltersTools`, leveraging the `RaindropCacheService`. The cache implementation correctly differentiates between varying query parameters by constructing unique cache keys. It also properly clones the `AvailableFilters` object out of the cache to avoid reference sharing, and safely clears the cache via `InvalidateAllAsync`.

🎯 **Why:** Previously, the `GetAvailableFiltersAsync` tool was making a direct API call on every invocation. For endpoints that frequently request the same data (such as getting the tags filter for the "all bookmarks" root collection), this led to unnecessary latency and API consumption.

📊 **Measured Improvement:**
A `FiltersToolsBenchmark` was added using `BenchmarkDotNet` to measure the tool's performance against a mock API simulating a 50ms latency (the baseline). 
- **Baseline (Uncached):** 51.85 ms
- **Optimized (Cached):** 1.57 us
- **Improvement:** Reduced latency by over ~33,000x for subsequent calls with the exact same parameters. By bypassing the simulated API overhead, it functions instantaneously from memory.

---
*PR created automatically by Jules for task [836166366234551627](https://jules.google.com/task/836166366234551627) started by @g1ddy*