### PR TITLE
🛡️ Sentinel: [security improvement] Add MaxLength to Title fields

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,8 @@
 **Vulnerability:** The application was exposing internal framework details (stack traces) to stderr when starting without required configurations (like the Raindrop API token).
 **Learning:** By default, .NET Generic Host allows configuration validation exceptions to crash the application, resulting in a verbose, generic stack trace that leaks internal code paths and framework versions.
 **Prevention:** Implement fail-fast configuration checks early in the application startup pipeline (Program.cs) before the main Host run loop. Catch OptionsValidationException to provide clean, generic error messages and exit gracefully (Environment.Exit), preventing stack trace leaks.
+
+## 2024-05-28 - Missing Validation on Title Fields
+**Vulnerability:** Several domain entities (`Raindrop`, `Highlight`) and DTOs (`RaindropCreateRequest`, `RaindropUpdateRequest`) lacked `[MaxLength]` validation attributes on the `Title` property, posing a risk of denial-of-service (DoS) or unexpected database constraints violations if exceptionally large strings are passed. This could lead to excessive memory consumption, particularly when processing or transforming this data locally (e.g., in ArrayPool allocations within `Sanitize`).
+**Learning:** Shared domain entities and DTOs must maintain consistent data length limits across all text fields that handle arbitrary user input.
+**Prevention:** Always verify and apply `[MaxLength(MaxTextFieldLength)]` constraint onto text properties (like `Title`, `Description`, `Excerpt`, `Note`) in domain models and request DTOs used for user input and data parsing.

--- a/src/Mcp/Highlights/Highlight.cs
+++ b/src/Mcp/Highlights/Highlight.cs
@@ -19,6 +19,7 @@ public record Highlight
     [Description("Highlighted text")]
     public string? Text { get; init; }
 
+    [MaxLength(Raindrop.MaxTextFieldLength)]
     [Description("Title of the bookmarked page")]
     public string? Title { get; init; }
 

--- a/src/Mcp/Raindrops/Raindrop.cs
+++ b/src/Mcp/Raindrops/Raindrop.cs
@@ -23,6 +23,7 @@ public record Raindrop
     public long Id { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [MaxLength(MaxTextFieldLength)]
     [Description("Title of the bookmarked page")]
     public string? Title { get; init; }
 

--- a/src/Mcp/Raindrops/RaindropCreateRequest.cs
+++ b/src/Mcp/Raindrops/RaindropCreateRequest.cs
@@ -14,6 +14,7 @@ public record RaindropCreateRequest : IRaindropRequest
     [Description("The URL of the bookmark. This field is required.")]
     public string Link { get; init; } = string.Empty;
 
+    [MaxLength(Raindrop.MaxTextFieldLength)]
     [Description("The title of the bookmark. If not provided, Raindrop.io will attempt to parse it from the URL.")]
     public string? Title { get; init; }
 

--- a/src/Mcp/Raindrops/RaindropUpdateRequest.cs
+++ b/src/Mcp/Raindrops/RaindropUpdateRequest.cs
@@ -13,6 +13,7 @@ public record RaindropUpdateRequest : IRaindropRequest
     [Description("The new URL for the bookmark.")]
     public string? Link { get; init; }
 
+    [MaxLength(Raindrop.MaxTextFieldLength)]
     [Description("The new title for the bookmark.")]
     public string? Title { get; init; }
 


### PR DESCRIPTION
**Severity:** MEDIUM
**Vulnerability:** Missing input length limits on the `Title` property in `Raindrop`, `Highlight`, `RaindropCreateRequest`, and `RaindropUpdateRequest` classes.
**Impact:** Unbounded text input for `Title` poses a risk of denial-of-service (DoS) or unexpected database constraints violations. This could lead to excessive memory consumption, particularly when processing or transforming this data locally (e.g., in ArrayPool allocations within `Sanitize`).
**Fix:** Added `[MaxLength(MaxTextFieldLength)]` attribute to the `Title` property in the affected classes, ensuring consistent length limits across the application.
**Verification:** Ran the full test suite using `dotnet test`. No regressions introduced, and the build passes cleanly.

---
*PR created automatically by Jules for task [10544371320556588226](https://jules.google.com/task/10544371320556588226) started by @g1ddy*