### PR TITLE
🛡️ Sentinel: [MEDIUM] Add MaxLength validation to TagRenameRequest

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -36,3 +36,8 @@
 **Vulnerability:** Several domain entities (`Raindrop`, `Highlight`) and DTOs (`RaindropCreateRequest`, `RaindropUpdateRequest`) lacked `[MaxLength]` validation attributes on the `Title` property, posing a risk of denial-of-service (DoS) or unexpected database constraints violations if exceptionally large strings are passed. This could lead to excessive memory consumption, particularly when processing or transforming this data locally (e.g., in ArrayPool allocations within `Sanitize`).
 **Learning:** Shared domain entities and DTOs must maintain consistent data length limits across all text fields that handle arbitrary user input.
 **Prevention:** Always verify and apply `[MaxLength(MaxTextFieldLength)]` constraint onto text properties (like `Title`, `Description`, `Excerpt`, `Note`) in domain models and request DTOs used for user input and data parsing.
+
+## $(date +%Y-%m-%d) - Prevent DoS from Large String Allocations in TagRenameRequest
+**Vulnerability:** The `Replace` property in `TagRenameRequest` lacked input length validation, allowing potentially unbounded string allocations.
+**Learning:** Even internal API wrappers and DTOs that do not directly hit a database must have input limits (`[MaxLength]`) to prevent Denial of Service (DoS) attacks caused by memory exhaustion, especially when the underlying API or serialization process might choke on extremely large strings.
+**Prevention:** Apply `[MaxLength]` validation using the domain's maximum string constants (like `Raindrops.Raindrop.MaxTextFieldLength`) to all user-provided string properties in Request DTOs, ensuring consistency with domain rules.

--- a/src/Mcp/Tags/TagRenameRequest.cs
+++ b/src/Mcp/Tags/TagRenameRequest.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace Mcp.Tags;
@@ -10,6 +11,7 @@ namespace Mcp.Tags;
 public record TagRenameRequest
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [MaxLength(Raindrops.Raindrop.MaxTextFieldLength)]
     [Description("New tag value to replace existing tags")]
     public string? Replace { get; init; }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `Replace` property in the `TagRenameRequest` DTO lacked a string length constraint. This unbounded string property could be exploited by providing excessively large strings, leading to excessive memory allocation and a potential Denial of Service (DoS).
🎯 Impact: An attacker or malicious input could cause the application to consume excessive memory, potentially crashing the service or impacting its performance when serializing requests or processing the tag rename.
🔧 Fix: Added `[MaxLength(Raindrops.Raindrop.MaxTextFieldLength)]` to the `Replace` property in `TagRenameRequest.cs`, aligning its validation with the constant defined in the `Raindrop` domain entity. Also added the required using statement for `System.ComponentModel.DataAnnotations`.
✅ Verification: Ran `dotnet build` and verified that the project compiles cleanly. Ran `dotnet test tests/Mcp.Tests/RaindropMcp.Tests.csproj` and confirmed all tests pass.

---
*PR created automatically by Jules for task [17515933197905856072](https://jules.google.com/task/17515933197905856072) started by @g1ddy*