### PR TITLE
chore: resolve Refit certificate issue and update dependencies

### DIFF
--- a/src/Mcp/RaindropMcp.csproj
+++ b/src/Mcp/RaindropMcp.csproj
@@ -37,13 +37,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
     <!-- <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.3" /> -->
-    <PackageReference Include="ModelContextProtocol" Version="1.3.0" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="10.1.6" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/tests/Mcp.Tests/RaindropMcp.Tests.csproj
+++ b/tests/Mcp.Tests/RaindropMcp.Tests.csproj
@@ -14,10 +14,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
This PR resolves the `Refit.HttpClientFactory` certificate revocation issue ("The author primary signature found a chain building issue") that prevented successful builds on version 10.1.6.

Changes include:
- Bumping `Refit.HttpClientFactory` to `11.0.1` in `src/Mcp/RaindropMcp.csproj`.
- Updating all `Microsoft.Extensions.*` packages to version `10.0.9` in both `RaindropMcp.csproj` and `RaindropMcp.Tests.csproj` to keep versions consolidated across the solution.
- Updating `ModelContextProtocol` to `1.4.0`.

These changes have been locally built and all tests pass. Central Package Management was intentionally not used, per user preference.

---
*PR created automatically by Jules for task [12013912253911785615](https://jules.google.com/task/12013912253911785615) started by @g1ddy*