### PR TITLE
feat: Add claude/channel experimental support

### DIFF
--- a/src/Mcp/Program.cs
+++ b/src/Mcp/Program.cs
@@ -16,9 +16,13 @@ builder.Logging.AddConsole(o => o.LogToStandardErrorThreshold = LogLevel.Trace);
 
 // Add the MCP services: the transport to use (stdio) and the tools to register.
 builder.Services
+    .AddHostedService<Mcp.Raindrops.RaindropMonitorService>()
     .AddRaindropApiClient(builder.Configuration)
     .AddMcpServer(options =>
     {
+        options.Capabilities ??= new ModelContextProtocol.Protocol.ServerCapabilities();
+        options.Capabilities.Experimental ??= new System.Collections.Generic.Dictionary<string, object>();
+        options.Capabilities.Experimental["claude/channel"] = new object();
         options.ServerInstructions = """
             This Raindrop MCP server exposes bookmark-management tools for Raindrop.io.
             Follow the workflow: Explore → Plan → Create → Move → Verify.

--- a/src/Mcp/Program.cs
+++ b/src/Mcp/Program.cs
@@ -25,6 +25,7 @@ builder.Services
         options.Capabilities.Experimental["claude/channel"] = new object();
         options.ServerInstructions = """
             This Raindrop MCP server exposes bookmark-management tools for Raindrop.io.
+            Note: This server fires background notifications to the `claude/channel` when new bookmarks are detected.
             Follow the workflow: Explore → Plan → Create → Move → Verify.
             Start with ListCollections and ListChildCollections to review your hierarchy.
             Create new collections using the parent field for subcollections.

--- a/src/Mcp/Raindrops/RaindropMonitorService.cs
+++ b/src/Mcp/Raindrops/RaindropMonitorService.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using ModelContextProtocol.Server;
+using ModelContextProtocol;
+using Mcp.Common;
+
+namespace Mcp.Raindrops;
+
+public class RaindropMonitorService : BackgroundService
+{
+    private readonly McpServer _server;
+    private readonly IRaindropsApi _apiClient;
+
+    // First Boot Strategy: Look back exactly 10 minutes from startup
+    private DateTime _newestBookmarkSeen = DateTime.UtcNow.AddMinutes(-10);
+
+    public RaindropMonitorService(McpServer server, IRaindropsApi apiClient)
+    {
+        _server = server;
+        _apiClient = apiClient;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Kicks off the first check immediately upon startup without blocking the server handshake
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                // Fetch recent bookmarks from the API (collection 0 = all)
+                // We'll get the first page of recent bookmarks, ordered by created desc
+                var response = await _apiClient.ListAsync(0, null, "-created", 0, 50, true, stoppingToken);
+                if (response?.Result == true && response.Items != null)
+                {
+                    var newBookmarks = new List<Raindrop>();
+
+                    foreach (var bookmark in response.Items)
+                    {
+                        if (bookmark.Created <= _newestBookmarkSeen) break;
+                        newBookmarks.Add(bookmark);
+                    }
+
+                    if (newBookmarks.Any())
+                    {
+                        // Process oldest to newest so Claude reads them in chronological order
+                        newBookmarks.Reverse();
+
+                        foreach (var bookmark in newBookmarks)
+                        {
+                            // MUST be awaited. Synchronous writes can deadlock the Stdio stream.
+                            await _server.SendNotificationAsync("notifications/claude/channel", new
+                            {
+                                content = $"New bookmark: {bookmark.Title}\nURL: {bookmark.Link}",
+                                meta = new { severity = "info" }
+                            });
+                        }
+
+                        _newestBookmarkSeen = newBookmarks.Last().Created.GetValueOrDefault(DateTime.UtcNow);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Simple retry: Log to stderr (never stdout!) and let the loop naturally wait 10 mins
+                Console.Error.WriteLine($"[RaindropMonitor] Best-effort sync failed: {ex.Message}");
+            }
+
+            // Wait 10 minutes before the next loop
+            await Task.Delay(TimeSpan.FromMinutes(10), stoppingToken);
+        }
+    }
+}

--- a/src/Mcp/Raindrops/RaindropMonitorService.cs
+++ b/src/Mcp/Raindrops/RaindropMonitorService.cs
@@ -10,18 +10,22 @@ using Mcp.Common;
 
 namespace Mcp.Raindrops;
 
+using Microsoft.Extensions.Logging;
+
 public class RaindropMonitorService : BackgroundService
 {
     private readonly McpServer _server;
     private readonly IRaindropsApi _apiClient;
+    private readonly ILogger<RaindropMonitorService> _logger;
 
     // First Boot Strategy: Look back exactly 10 minutes from startup
     private DateTime _newestBookmarkSeen = DateTime.UtcNow.AddMinutes(-10);
 
-    public RaindropMonitorService(McpServer server, IRaindropsApi apiClient)
+    public RaindropMonitorService(McpServer server, IRaindropsApi apiClient, ILogger<RaindropMonitorService> logger)
     {
         _server = server;
         _apiClient = apiClient;
+        _logger = logger;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -40,7 +44,8 @@ public class RaindropMonitorService : BackgroundService
 
                     foreach (var bookmark in response.Items)
                     {
-                        if (bookmark.Created <= _newestBookmarkSeen) break;
+                        if (!bookmark.Created.HasValue) continue;
+                        if (bookmark.Created.Value.ToUniversalTime() <= _newestBookmarkSeen) break;
                         newBookmarks.Add(bookmark);
                     }
 
@@ -54,19 +59,19 @@ public class RaindropMonitorService : BackgroundService
                             // MUST be awaited. Synchronous writes can deadlock the Stdio stream.
                             await _server.SendNotificationAsync("notifications/claude/channel", new
                             {
-                                content = $"New bookmark: {bookmark.Title}\nURL: {bookmark.Link}",
+                                content = $"New bookmark: {bookmark.Title}\nURL: {bookmark.Link}\nID: {bookmark.Id}",
                                 meta = new { severity = "info" }
                             });
                         }
 
-                        _newestBookmarkSeen = newBookmarks.Last().Created.GetValueOrDefault(DateTime.UtcNow);
+                        _newestBookmarkSeen = newBookmarks.Last().Created!.Value.ToUniversalTime();
                     }
                 }
             }
             catch (Exception ex)
             {
-                // Simple retry: Log to stderr (never stdout!) and let the loop naturally wait 10 mins
-                Console.Error.WriteLine($"[RaindropMonitor] Best-effort sync failed: {ex.Message}");
+                // Simple retry: let the loop naturally wait 10 mins
+                _logger.LogError(ex, "[RaindropMonitor] Best-effort sync failed: {Message}", ex.Message);
             }
 
             // Wait 10 minutes before the next loop

--- a/src/Mcp/Raindrops/RaindropMonitorService.cs
+++ b/src/Mcp/Raindrops/RaindropMonitorService.cs
@@ -10,6 +10,7 @@ using Mcp.Common;
 
 namespace Mcp.Raindrops;
 
+using System.Text;
 using Microsoft.Extensions.Logging;
 
 public class RaindropMonitorService : BackgroundService
@@ -38,35 +39,45 @@ public class RaindropMonitorService : BackgroundService
                 // Fetch recent bookmarks from the API (collection 0 = all)
                 // We'll get the first page of recent bookmarks, ordered by created desc
                 var response = await _apiClient.ListAsync(0, null, "-created", 0, 50, true, stoppingToken);
-                if (response?.Result == true && response.Items != null)
+                if (response?.Result != true || response.Items == null)
+                    continue;
+
+                var newBookmarks = new List<Raindrop>();
+
+                foreach (var bookmark in response.Items)
                 {
-                    var newBookmarks = new List<Raindrop>();
-
-                    foreach (var bookmark in response.Items)
-                    {
-                        if (!bookmark.Created.HasValue) continue;
-                        if (bookmark.Created.Value.ToUniversalTime() <= _newestBookmarkSeen) break;
-                        newBookmarks.Add(bookmark);
-                    }
-
-                    if (newBookmarks.Any())
-                    {
-                        // Process oldest to newest so Claude reads them in chronological order
-                        newBookmarks.Reverse();
-
-                        foreach (var bookmark in newBookmarks)
-                        {
-                            // MUST be awaited. Synchronous writes can deadlock the Stdio stream.
-                            await _server.SendNotificationAsync("notifications/claude/channel", new
-                            {
-                                content = $"New bookmark: {bookmark.Title}\nURL: {bookmark.Link}\nID: {bookmark.Id}",
-                                meta = new { severity = "info" }
-                            });
-                        }
-
-                        _newestBookmarkSeen = newBookmarks.Last().Created!.Value.ToUniversalTime();
-                    }
+                    if (!bookmark.Created.HasValue) continue;
+                    if (bookmark.Created.Value.ToUniversalTime() <= _newestBookmarkSeen) break;
+                    newBookmarks.Add(bookmark);
                 }
+
+                if (!newBookmarks.Any())
+                    continue;
+
+                // 1. Process oldest to newest
+                newBookmarks.Reverse();
+
+                // 2. Build the bulk payload
+                var contentBuilder = new StringBuilder();
+                contentBuilder.AppendLine($"Detected {newBookmarks.Count} new bookmarks:");
+
+                foreach (var bookmark in newBookmarks)
+                {
+                    contentBuilder.AppendLine($"- [{bookmark.Title}]({bookmark.Link}) (ID: {bookmark.Id})");
+                }
+
+                // 3. Send exactly once per 10-minute cycle
+                await _server.SendNotificationAsync("notifications/claude/channel", new
+                {
+                    content = contentBuilder.ToString(),
+                    meta = new
+                    {
+                        severity = "info",
+                        batch_count = newBookmarks.Count // Helpful metadata for Claude to know the scale
+                    }
+                });
+
+                _newestBookmarkSeen = newBookmarks.Last().Created!.Value.ToUniversalTime();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### What
- Registers `claude/channel` as an experimental capability in `McpServerOptions`.
- Adds a new `RaindropMonitorService` hosted service that checks for new bookmarks using a sliding high-water mark timestamp.
- Broadcasts real-time notifications via standard I/O whenever new bookmarks are created.

### Why
To allow clients like Claude Code to listen for background events without having to explicitly ask for status updates, maintaining context across tasks transparently.

### How
By continuously polling the Raindrop API every 10 minutes and pushing one-way notifications (`notifications/claude/channel`) containing the bookmark details. All exceptions or diagnostic logs are carefully routed to `Console.Error` to preserve the `stdio` JSON-RPC stream integrity.

---
*PR created automatically by Jules for task [4791162983170335488](https://jules.google.com/task/4791162983170335488) started by @g1ddy*