### PR TITLE
Refactor getting newest bookmarks consolidation

### DIFF
--- a/src/Mcp/Raindrops/RaindropMonitorService.cs
+++ b/src/Mcp/Raindrops/RaindropMonitorService.cs
@@ -37,19 +37,7 @@ public class RaindropMonitorService : BackgroundService
             try
             {
                 // Fetch recent bookmarks from the API (collection 0 = all)
-                // We'll get the first page of recent bookmarks, ordered by created desc
-                var response = await _apiClient.ListAsync(0, null, "-created", 0, 50, true, stoppingToken);
-                if (response?.Result != true || response.Items == null)
-                    continue;
-
-                var newBookmarks = new List<Raindrop>();
-
-                foreach (var bookmark in response.Items)
-                {
-                    if (!bookmark.Created.HasValue) continue;
-                    if (bookmark.Created.Value.ToUniversalTime() <= _newestBookmarkSeen) break;
-                    newBookmarks.Add(bookmark);
-                }
+                var newBookmarks = (await _apiClient.GetNewestSinceAsync(_newestBookmarkSeen, 0, stoppingToken)).ToList();
 
                 if (!newBookmarks.Any())
                     continue;

--- a/src/Mcp/Raindrops/RaindropsExtensions.cs
+++ b/src/Mcp/Raindrops/RaindropsExtensions.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Mcp.Common;
+
+namespace Mcp.Raindrops;
+
+/// <summary>
+/// Extension methods for <see cref="IRaindropsApi"/>.
+/// </summary>
+public static class RaindropsExtensions
+{
+    /// <summary>
+    /// Fetches all bookmarks created after a specific date, handling pagination automatically.
+    /// </summary>
+    /// <param name="api">The API client.</param>
+    /// <param name="since">The cutoff date (exclusive).</param>
+    /// <param name="collectionId">The collection ID (0 for all).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of bookmarks newer than the specified date, ordered from newest to oldest.</returns>
+    public static async Task<IReadOnlyList<Raindrop>> GetNewestSinceAsync(
+        this IRaindropsApi api,
+        DateTime since,
+        int collectionId = 0,
+        CancellationToken cancellationToken = default)
+    {
+        var newBookmarks = new List<Raindrop>();
+        int page = 0;
+        const int perPage = 50;
+        var sinceUtc = since.ToUniversalTime();
+
+        while (true)
+        {
+            var response = await api.ListAsync(collectionId, null, "-created", page, perPage, true, cancellationToken);
+            if (response?.Result != true || response.Items == null || !response.Items.Any())
+                break;
+
+            bool reachedSeen = false;
+            foreach (var bookmark in response.Items)
+            {
+                if (!bookmark.Created.HasValue) continue;
+
+                if (bookmark.Created.Value.ToUniversalTime() <= sinceUtc)
+                {
+                    reachedSeen = true;
+                    break;
+                }
+                newBookmarks.Add(bookmark);
+            }
+
+            if (reachedSeen || response.Items.Count < perPage)
+                break;
+
+            page++;
+        }
+
+        return newBookmarks;
+    }
+}

--- a/tests/Mcp.Tests/RaindropsExtensionsTests.cs
+++ b/tests/Mcp.Tests/RaindropsExtensionsTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Mcp.Common;
+using Mcp.Raindrops;
+using Moq;
+using Xunit;
+
+namespace Mcp.Tests;
+
+public class RaindropsExtensionsTests
+{
+    [Fact]
+    public async Task GetNewestSinceAsync_FiltersBookmarksCorrectly()
+    {
+        // Arrange
+        var mockApi = new Mock<IRaindropsApi>();
+        var since = new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        var bookmarks = new List<Raindrop>
+        {
+            new() { Id = 1, Created = since.AddMinutes(10) },
+            new() { Id = 2, Created = since.AddMinutes(5) },
+            new() { Id = 3, Created = since }, // Should be excluded (exclusive)
+            new() { Id = 4, Created = since.AddMinutes(-5) } // Should be excluded
+        };
+
+        mockApi.Setup(api => api.ListAsync(0, null, "-created", 0, 50, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ItemsResponse<Raindrop>(true, bookmarks));
+
+        // Act
+        var result = await mockApi.Object.GetNewestSinceAsync(since);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, b => b.Id == 1);
+        Assert.Contains(result, b => b.Id == 2);
+        Assert.DoesNotContain(result, b => b.Id == 3);
+        Assert.DoesNotContain(result, b => b.Id == 4);
+    }
+
+    [Fact]
+    public async Task GetNewestSinceAsync_HandlesMultiplePages()
+    {
+        // Arrange
+        var mockApi = new Mock<IRaindropsApi>();
+        var since = new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        // Page 0: all new
+        var page0 = Enumerable.Range(1, 50).Select(i => new Raindrop
+        {
+            Id = i,
+            Created = since.AddDays(1).AddMinutes(-i)
+        }).ToList();
+
+        // Page 1: some new, some old
+        var page1 = new List<Raindrop>
+        {
+            new() { Id = 51, Created = since.AddMinutes(1) },
+            new() { Id = 52, Created = since }, // Cutoff
+            new() { Id = 53, Created = since.AddMinutes(-1) }
+        };
+
+        mockApi.Setup(api => api.ListAsync(0, null, "-created", 0, 50, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ItemsResponse<Raindrop>(true, page0));
+
+        mockApi.Setup(api => api.ListAsync(0, null, "-created", 1, 50, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ItemsResponse<Raindrop>(true, page1));
+
+        // Act
+        var result = await mockApi.Object.GetNewestSinceAsync(since);
+
+        // Assert
+        Assert.Equal(51, result.Count);
+        Assert.Contains(result, b => b.Id == 51);
+        Assert.DoesNotContain(result, b => b.Id == 52);
+    }
+}


### PR DESCRIPTION
This PR refactors the logic for retrieving bookmarks created since a specific date into a reusable extension method `GetNewestSinceAsync`.

Key changes:
- Created `src/Mcp/Raindrops/RaindropsExtensions.cs` containing `GetNewestSinceAsync`.
- The new method handles pagination automatically, ensuring all bookmarks since the cutoff are retrieved (improving over the previous 50-item limit).
- Refactored `RaindropMonitorService.cs` to use this new method, simplifying its implementation.
- Added `tests/Mcp.Tests/RaindropsExtensionsTests.cs` with unit tests for single-page and multi-page scenarios.

Fixes #167

---
*PR created automatically by Jules for task [17159095419186311090](https://jules.google.com/task/17159095419186311090) started by @g1ddy*