### PR TITLE
Fix: Update MinVer configuration to read tags correctly

### DIFF
--- a/src/Mcp/RaindropMcp.csproj
+++ b/src/Mcp/RaindropMcp.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerDefaultPreReleaseIdentifiers>beta</MinVerDefaultPreReleaseIdentifiers>
     <TargetFramework>net10.0</TargetFramework>
     <RollForward>Major</RollForward>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Fix MinVer versioning output for NuGet publish actions. Added project-level property tags to inform MinVer of the `v` prefix in git tags, and correctly default pre-releases to `beta`.

---
*PR created automatically by Jules for task [10381884263490311821](https://jules.google.com/task/10381884263490311821) started by @g1ddy*