### PR TITLE
feat: dynamically inject package version into server.json

### DIFF
--- a/src/Mcp/RaindropMcp.csproj
+++ b/src/Mcp/RaindropMcp.csproj
@@ -32,11 +32,24 @@
     <None Update="appsettings.Development.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <!-- The source server.json is not packed directly anymore. It's updated in the target below. -->
     <Content Include="server.json">
-      <Pack>true</Pack>
-      <PackagePath>.mcp/</PackagePath>
+      <Pack>false</Pack>
     </Content>
   </ItemGroup>
+
+  <Target Name="InjectVersionIntoServerJson" BeforeTargets="GenerateNuspec">
+    <PropertyGroup>
+      <IntermediateServerJsonPath>$(IntermediateOutputPath)server.json</IntermediateServerJsonPath>
+    </PropertyGroup>
+    <Message Importance="High" Text="Injecting PackageVersion ($(PackageVersion)) into server.json" />
+    <WriteLinesToFile File="$(IntermediateServerJsonPath)" Lines="$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)/server.json').Replace('0.0.0-dev', '$(PackageVersion)'))" Overwrite="true" />
+    <ItemGroup>
+      <_PackageFiles Include="$(IntermediateServerJsonPath)">
+        <PackagePath>.mcp/server.json</PackagePath>
+      </_PackageFiles>
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />

--- a/src/Mcp/RaindropMcp.csproj
+++ b/src/Mcp/RaindropMcp.csproj
@@ -38,16 +38,15 @@
     </Content>
   </ItemGroup>
 
-  <Target Name="InjectVersionIntoServerJson" BeforeTargets="GenerateNuspec">
+  <Target Name="InjectVersionIntoServerJson" BeforeTargets="_GetPackageFiles">
     <PropertyGroup>
       <IntermediateServerJsonPath>$(IntermediateOutputPath)server.json</IntermediateServerJsonPath>
     </PropertyGroup>
     <Message Importance="High" Text="Injecting PackageVersion ($(PackageVersion)) into server.json" />
+    <MakeDir Directories="$(IntermediateOutputPath)" />
     <WriteLinesToFile File="$(IntermediateServerJsonPath)" Lines="$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)/server.json').Replace('0.0.0-dev', '$(PackageVersion)'))" Overwrite="true" />
     <ItemGroup>
-      <_PackageFiles Include="$(IntermediateServerJsonPath)">
-        <PackagePath>.mcp/server.json</PackagePath>
-      </_PackageFiles>
+      <None Include="$(IntermediateServerJsonPath)" Pack="true" PackagePath=".mcp/server.json" />
     </ItemGroup>
   </Target>
 

--- a/src/Mcp/server.json
+++ b/src/Mcp/server.json
@@ -8,6 +8,10 @@
         "--prerelease",
         "--yes"
       ],
+      "nuget": {
+        "id": "Raindrop.Mcp.DotNet",
+        "version": "0.0.0-dev"
+      },
       "env": {
         "Raindrop:ApiToken": "${env:RAINDROP_API_TOKEN}",
         "Raindrop:BaseUrl": "https://api.raindrop.io/rest/v1"

--- a/tests/Mcp.Tests/ServerJsonTests.cs
+++ b/tests/Mcp.Tests/ServerJsonTests.cs
@@ -28,6 +28,7 @@ public class ServerJsonTests
         var raindropServer = servers.GetProperty("RaindropMcp");
         var command = raindropServer.GetProperty("command").GetString();
         var args = raindropServer.GetProperty("args");
+        var nuget = raindropServer.GetProperty("nuget");
 
         // Assert
         Assert.Equal("dnx", command);
@@ -35,6 +36,10 @@ public class ServerJsonTests
         // Verify args contains the package name
         var argsArray = args.EnumerateArray().Select(a => a.GetString()).ToArray();
         Assert.Contains("Raindrop.Mcp.DotNet", argsArray);
+
+        // Verify nuget properties
+        Assert.Equal("Raindrop.Mcp.DotNet", nuget.GetProperty("id").GetString());
+        Assert.Equal("0.0.0-dev", nuget.GetProperty("version").GetString());
     }
 
     private string FindRepoRoot()


### PR DESCRIPTION
This pull request adds support for a `nuget` block inside the MCP `server.json` file. 

Because `server.json` is distributed inside the tool's NuGet package, keeping its version hardcoded would lead to mismatched installation commands. To solve this, this PR:
1. Adds a placeholder `nuget` object to the source `server.json` file.
2. Intercepts the packaging process via an MSBuild target (`InjectVersionIntoServerJson`) running before `GenerateNuspec`.
3. Dynamically injects the computed `$(PackageVersion)` into the `server.json` content and writes it to an intermediate output directory.
4. Includes the modified file in the `.nupkg` via the `<_PackageFiles>` item group (excluding the original source file).
5. Updates tests to ensure the base structure exists.

This allows users generating their VS Code MCP configurations to automatically pull the correctly versioned package.

---
*PR created automatically by Jules for task [6320553885561544371](https://jules.google.com/task/6320553885561544371) started by @g1ddy*