### PR TITLE
chore: Add PackageLicenseExpression to resolve NuGet warning

### DIFF
--- a/src/Mcp/RaindropMcp.csproj
+++ b/src/Mcp/RaindropMcp.csproj
@@ -15,6 +15,7 @@
 
     <!-- Set recommended package metadata -->
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageId>Raindrop.Mcp.DotNet</PackageId>
     <Authors>g1ddy</Authors>
     <PackageTags>AI; MCP; server; stdio</PackageTags>


### PR DESCRIPTION
Fixes a warning generated by `dotnet pack` about missing license information in the NuGet package.
This adds the `PackageLicenseExpression` property to the `.csproj` file, matching the MIT license present in the root directory.

---
*PR created automatically by Jules for task [6741389430270604238](https://jules.google.com/task/6741389430270604238) started by @g1ddy*