### PR TITLE
fix: properly inject dynamic package version into server.json

### DIFF
--- a/src/Mcp/RaindropMcp.csproj
+++ b/src/Mcp/RaindropMcp.csproj
@@ -38,7 +38,7 @@
     </Content>
   </ItemGroup>
 
-  <Target Name="InjectVersionIntoServerJson" BeforeTargets="_GetPackageFiles">
+  <Target Name="InjectVersionIntoServerJson" BeforeTargets="GenerateNuspec">
     <PropertyGroup>
       <IntermediateServerJsonPath>$(IntermediateOutputPath)server.json</IntermediateServerJsonPath>
     </PropertyGroup>
@@ -46,7 +46,7 @@
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <WriteLinesToFile File="$(IntermediateServerJsonPath)" Lines="$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)/server.json').Replace('0.0.0-dev', '$(PackageVersion)'))" Overwrite="true" />
     <ItemGroup>
-      <None Include="$(IntermediateServerJsonPath)" Pack="true" PackagePath=".mcp/server.json" />
+      <_PackageFiles Include="$(IntermediateServerJsonPath)" PackagePath=".mcp/server.json" />
     </ItemGroup>
   </Target>
 

--- a/src/Mcp/RaindropMcp.csproj
+++ b/src/Mcp/RaindropMcp.csproj
@@ -9,6 +9,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 
+    <!-- Extensibility point for adding files dynamically -->
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);InjectVersionIntoServerJson</TargetsForTfmSpecificContentInPackage>
+
     <!-- Set up the NuGet package to be an MCP server -->
     <PackAsTool>true</PackAsTool>
     <PackageType>McpServer</PackageType>
@@ -38,7 +41,7 @@
     </Content>
   </ItemGroup>
 
-  <Target Name="InjectVersionIntoServerJson" BeforeTargets="GenerateNuspec">
+  <Target Name="InjectVersionIntoServerJson">
     <PropertyGroup>
       <IntermediateServerJsonPath>$(IntermediateOutputPath)server.json</IntermediateServerJsonPath>
     </PropertyGroup>
@@ -46,7 +49,7 @@
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <WriteLinesToFile File="$(IntermediateServerJsonPath)" Lines="$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)/server.json').Replace('0.0.0-dev', '$(PackageVersion)'))" Overwrite="true" />
     <ItemGroup>
-      <_PackageFiles Include="$(IntermediateServerJsonPath)" PackagePath=".mcp/server.json" />
+      <TfmSpecificPackageFile Include="$(IntermediateServerJsonPath)" PackagePath=".mcp/server.json" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This change ensures that `server.json` inside the NuGet package contains the actual dynamic package version rather than a placeholder.

---
*PR created automatically by Jules for task [3061517749823160462](https://jules.google.com/task/3061517749823160462) started by @g1ddy*