### PR TITLE
fix: ensure MinVer executes before injecting package version into server.json

### DIFF
--- a/src/Mcp/RaindropMcp.csproj
+++ b/src/Mcp/RaindropMcp.csproj
@@ -42,7 +42,7 @@
     </Content>
   </ItemGroup>
 
-  <Target Name="InjectVersionIntoServerJson">
+  <Target Name="InjectVersionIntoServerJson" DependsOnTargets="MinVer">
     <PropertyGroup>
       <IntermediateServerJsonPath>$(IntermediateOutputPath)server.json</IntermediateServerJsonPath>
     </PropertyGroup>


### PR DESCRIPTION
Fixes an issue where the `server.json` inside the published MCP NuGet package contained the wrong version.

The MSBuild target responsible for replacing `0.0.0-dev` with the current package version was executing prior to the `MinVer` tool running. Because of this, it used the default package version (`1.0.0`). Adding `DependsOnTargets="MinVer"` explicitly makes MSBuild evaluate the `MinVer` target before the replacement target, injecting the correct package version into the final `server.json` artifact.

---
*PR created automatically by Jules for task [11382994828336349548](https://jules.google.com/task/11382994828336349548) started by @g1ddy*