### PR TITLE
fix: correct server.json schema and MSBuild injection during dotnet pack

### DIFF
--- a/src/Mcp/RaindropMcp.csproj
+++ b/src/Mcp/RaindropMcp.csproj
@@ -39,7 +39,7 @@
     </Content>
   </ItemGroup>
 
-  <Target Name="InjectVersionIntoServerJson" BeforeTargets="_GetPackageFiles" DependsOnTargets="MinVer">
+  <Target Name="InjectVersionIntoServerJson" BeforeTargets="GenerateNuspec" DependsOnTargets="MinVer">
     <PropertyGroup>
       <IntermediateServerJsonPath>$(IntermediateOutputPath)server.json</IntermediateServerJsonPath>
     </PropertyGroup>

--- a/src/Mcp/RaindropMcp.csproj
+++ b/src/Mcp/RaindropMcp.csproj
@@ -9,9 +9,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 
-    <!-- Extensibility point for adding files dynamically -->
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);InjectVersionIntoServerJson</TargetsForTfmSpecificContentInPackage>
-
     <!-- Set up the NuGet package to be an MCP server -->
     <PackAsTool>true</PackAsTool>
     <PackageType>McpServer</PackageType>
@@ -42,7 +39,7 @@
     </Content>
   </ItemGroup>
 
-  <Target Name="InjectVersionIntoServerJson" DependsOnTargets="MinVer">
+  <Target Name="InjectVersionIntoServerJson" BeforeTargets="_GetPackageFiles" DependsOnTargets="MinVer">
     <PropertyGroup>
       <IntermediateServerJsonPath>$(IntermediateOutputPath)server.json</IntermediateServerJsonPath>
     </PropertyGroup>
@@ -50,7 +47,7 @@
     <MakeDir Directories="$(IntermediateOutputPath)" />
     <WriteLinesToFile File="$(IntermediateServerJsonPath)" Lines="$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)/server.json').Replace('0.0.0-dev', '$(PackageVersion)'))" Overwrite="true" />
     <ItemGroup>
-      <TfmSpecificPackageFile Include="$(IntermediateServerJsonPath)" PackagePath=".mcp/server.json" />
+      <_PackageFiles Include="$(IntermediateServerJsonPath)" PackagePath=".mcp/server.json" />
     </ItemGroup>
   </Target>
 

--- a/src/Mcp/server.json
+++ b/src/Mcp/server.json
@@ -1,21 +1,45 @@
 {
-  "servers": {
-    "RaindropMcp": {
-      "type": "stdio",
-      "command": "dnx",
-      "args": [
-        "Raindrop.Mcp.DotNet",
-        "--prerelease",
-        "--yes"
-      ],
-      "nuget": {
-        "id": "Raindrop.Mcp.DotNet",
-        "version": "0.0.0-dev"
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.g1ddy/raindrop-mcp-dotnet",
+  "version": "0.0.0-dev",
+  "description": "A .NET-based MCP server for interacting with your Raindrop.io bookmarks using natural language.",
+  "title": "Raindrop MCP Server",
+  "websiteUrl": "https://github.com/g1ddy/raindrop-mcp-dotnet",
+  "packages": [
+    {
+      "registryType": "nuget",
+      "identifier": "Raindrop.Mcp.DotNet",
+      "version": "0.0.0-dev",
+      "transport": {
+        "type": "stdio"
       },
-      "env": {
-        "Raindrop:ApiToken": "${env:RAINDROP_API_TOKEN}",
-        "Raindrop:BaseUrl": "https://api.raindrop.io/rest/v1"
-      }
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "--prerelease"
+        },
+        {
+          "type": "positional",
+          "value": "--yes"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "Raindrop:ApiToken",
+          "description": "The API token for Raindrop.io. Generate this in the Raindrop.io settings under 'Integrations'.",
+          "isRequired": true
+        },
+        {
+          "name": "Raindrop:BaseUrl",
+          "description": "The base URL for the Raindrop.io API.",
+          "isRequired": false,
+          "defaultValue": "https://api.raindrop.io/rest/v1"
+        }
+      ]
     }
+  ],
+  "repository": {
+    "url": "https://github.com/g1ddy/raindrop-mcp-dotnet",
+    "source": "github"
   }
 }

--- a/tests/Mcp.Tests/ServerJsonTests.cs
+++ b/tests/Mcp.Tests/ServerJsonTests.cs
@@ -23,23 +23,27 @@ public class ServerJsonTests
         using var jsonDoc = JsonDocument.Parse(jsonContent);
 
         // Act
-        // Navigate to servers.RaindropMcp
-        var servers = jsonDoc.RootElement.GetProperty("servers");
-        var raindropServer = servers.GetProperty("RaindropMcp");
-        var command = raindropServer.GetProperty("command").GetString();
-        var args = raindropServer.GetProperty("args");
-        var nuget = raindropServer.GetProperty("nuget");
+        // Verify root properties
+        var schema = jsonDoc.RootElement.GetProperty("$schema").GetString();
+        var name = jsonDoc.RootElement.GetProperty("name").GetString();
+        var version = jsonDoc.RootElement.GetProperty("version").GetString();
 
         // Assert
-        Assert.Equal("dnx", command);
+        Assert.NotNull(schema);
+        Assert.Equal("io.github.g1ddy/raindrop-mcp-dotnet", name);
+        Assert.Equal("0.0.0-dev", version);
 
-        // Verify args contains the package name
-        var argsArray = args.EnumerateArray().Select(a => a.GetString()).ToArray();
-        Assert.Contains("Raindrop.Mcp.DotNet", argsArray);
+        // Verify packages array
+        var packages = jsonDoc.RootElement.GetProperty("packages");
+        Assert.True(packages.GetArrayLength() > 0);
 
-        // Verify nuget properties
-        Assert.Equal("Raindrop.Mcp.DotNet", nuget.GetProperty("id").GetString());
-        Assert.Equal("0.0.0-dev", nuget.GetProperty("version").GetString());
+        var firstPackage = packages[0];
+        Assert.Equal("nuget", firstPackage.GetProperty("registryType").GetString());
+        Assert.Equal("Raindrop.Mcp.DotNet", firstPackage.GetProperty("identifier").GetString());
+        Assert.Equal("0.0.0-dev", firstPackage.GetProperty("version").GetString());
+
+        var transportType = firstPackage.GetProperty("transport").GetProperty("type").GetString();
+        Assert.Equal("stdio", transportType);
     }
 
     private string FindRepoRoot()


### PR DESCRIPTION
Updates `server.json` to use the official MCP Server Manifest schema, satisfying NuGet.org validations which expect the `packages` array and `registryType: "nuget"`.

Additionally fixes the MSBuild target inside `RaindropMcp.csproj` by changing `TargetsForTfmSpecificContentInPackage` to `BeforeTargets="_GetPackageFiles"` and adding the modified file directly to `<_PackageFiles>` instead of `<TfmSpecificPackageFile>`. This ensures the dynamically versioned file is reliably packed into the `.mcp/` directory even when using `dotnet pack --no-build` in CI.

---
*PR created automatically by Jules for task [5631865545387689329](https://jules.google.com/task/5631865545387689329) started by @g1ddy*