### PR TITLE
feat: add visual bookmark explorer UI tool

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-14 - Improve Exception Messaging for MCP
 **Learning:** For this backend MCP server, UX improvements focus on the Developer/AI experience by ensuring exception messages (e.g., `ArgumentOutOfRangeException`) include the specific invalid values provided, and that schema descriptions offer explicit instructions. `ArgumentOutOfRangeException` natively includes the actual value when instantiated properly using `throw new ArgumentOutOfRangeException(nameof(param), paramValue, "Message");`.
 **Action:** When updating exceptions, make sure we provide `paramName`, `actualValue`, and `message` to `ArgumentOutOfRangeException`.
+
+## 2024-05-15 - [Blazor HtmlRenderer Integration for UI Views]
+**Learning:** Returning static UI views from MCP tools requires encapsulation of `HtmlRenderer` via a dedicated service (e.g., `IHtmlRenderingService`) to manage DI scope and dispatch rendering securely on the correct thread. In addition, using a unique `{id}` mapped via `UriTemplate` is crucial to prevent cache overwriting when the user navigates chat history. To allow Blazor `.razor` components to compile in the console app, the `Microsoft.NET.Sdk.Razor` SDK must be utilized.
+**Action:** Always create dedicated UI generation tools (leaving raw JSON tools untouched for headless reasoning), inject a proper caching mechanism for historical navigation, and utilize a dedicated HTML rendering service rather than injecting `IServiceProvider` directly.

--- a/src/Mcp/RaindropMcp.csproj
+++ b/src/Mcp/RaindropMcp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <MinVerTagPrefix>v</MinVerTagPrefix>
@@ -34,7 +34,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <!-- The source server.json is not packed directly anymore. It's updated in the target below. -->
-    <Content Include="server.json">
+    <Content Update="server.json">
       <Pack>false</Pack>
     </Content>
   </ItemGroup>
@@ -52,6 +52,7 @@
   </Target>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />

--- a/src/Mcp/RaindropServiceCollectionExtensions.cs
+++ b/src/Mcp/RaindropServiceCollectionExtensions.cs
@@ -37,6 +37,10 @@ public static class RaindropServiceCollectionExtensions
         services.AddSingleton<RaindropClientConfig>();
         services.AddSingleton<IRaindropCacheService, RaindropCacheService>();
 
+        // UI Services
+        services.AddSingleton<Mcp.Ui.IUiCacheService, Mcp.Ui.UiCacheService>();
+        services.AddSingleton<Mcp.Ui.IHtmlRenderingService, Mcp.Ui.HtmlRenderingService>();
+
         var settings = new RefitSettings
         {
             ContentSerializer = new SystemTextJsonContentSerializer(new System.Text.Json.JsonSerializerOptions

--- a/src/Mcp/Ui/Explorer.razor
+++ b/src/Mcp/Ui/Explorer.razor
@@ -1,0 +1,90 @@
+@namespace Mcp.Ui
+@using Microsoft.AspNetCore.Components
+@using Mcp.Raindrops
+@using System.Collections.Generic
+@using System.Linq
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bookmark Explorer</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@picocss/pico@2/css/pico.min.css">
+    <style>
+        .bookmark-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 1rem;
+        }
+        .bookmark-card {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+        }
+        .bookmark-card img {
+            max-width: 100%;
+            height: auto;
+            border-radius: var(--pico-border-radius);
+            margin-bottom: 1rem;
+        }
+        .bookmark-title {
+            font-size: 1.2rem;
+            margin-bottom: 0.5rem;
+            word-break: break-word;
+        }
+        .bookmark-excerpt {
+            font-size: 0.9rem;
+            color: var(--pico-muted-color);
+            margin-bottom: 1rem;
+        }
+        .bookmark-footer {
+            margin-top: auto;
+            font-size: 0.8rem;
+        }
+    </style>
+</head>
+<body>
+    <main class="container">
+        <h2>Bookmark Explorer</h2>
+        <div class="bookmark-grid">
+            @if (Bookmarks != null && Bookmarks.Any())
+            {
+                @foreach (var bookmark in Bookmarks)
+                {
+                    <article class="bookmark-card">
+                        <div>
+                            <header>
+                                @if (!string.IsNullOrEmpty(bookmark.Cover))
+                                {
+                                    <img src="@bookmark.Cover" alt="Cover image for @bookmark.Title" />
+                                }
+                                <div class="bookmark-title">
+                                    <strong>@bookmark.Title</strong>
+                                </div>
+                            </header>
+                            <p class="bookmark-excerpt">@bookmark.Excerpt</p>
+                        </div>
+                        <footer class="bookmark-footer">
+                            <a href="@bookmark.Link" target="_blank" rel="noopener noreferrer">Visit Link</a>
+                            @if (!string.IsNullOrEmpty(bookmark.Domain))
+                            {
+                                <span> &bull; @bookmark.Domain</span>
+                            }
+                        </footer>
+                    </article>
+                }
+            }
+            else
+            {
+                <p>No bookmarks to display.</p>
+            }
+        </div>
+    </main>
+</body>
+</html>
+
+@code {
+    [Parameter]
+    public required IEnumerable<Raindrop> Bookmarks { get; set; }
+}

--- a/src/Mcp/Ui/HtmlRenderingService.cs
+++ b/src/Mcp/Ui/HtmlRenderingService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.Web.HtmlRendering;
+using Microsoft.Extensions.Logging;
+using Mcp.Raindrops;
+
+namespace Mcp.Ui;
+
+/// <summary>
+/// Implementation of <see cref="IHtmlRenderingService"/> using <see cref="HtmlRenderer"/>.
+/// </summary>
+public class HtmlRenderingService : IHtmlRenderingService, IAsyncDisposable
+{
+    private readonly HtmlRenderer _htmlRenderer;
+
+    public HtmlRenderingService(IServiceProvider serviceProvider, ILoggerFactory loggerFactory)
+    {
+        _htmlRenderer = new HtmlRenderer(serviceProvider, loggerFactory);
+    }
+
+    public async Task<string> RenderBookmarksAsync(IEnumerable<Raindrop> bookmarks)
+    {
+        var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            { "Bookmarks", bookmarks }
+        });
+
+        // Use the renderer's Dispatcher.InvokeAsync to ensure thread safety
+        var html = await _htmlRenderer.Dispatcher.InvokeAsync(async () =>
+        {
+            var output = await _htmlRenderer.RenderComponentAsync<Explorer>(parameters);
+            return output.ToHtmlString();
+        });
+
+        return html;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _htmlRenderer.DisposeAsync();
+    }
+}

--- a/src/Mcp/Ui/IHtmlRenderingService.cs
+++ b/src/Mcp/Ui/IHtmlRenderingService.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mcp.Raindrops;
+
+namespace Mcp.Ui;
+
+/// <summary>
+/// Service for generating static HTML from Razor components.
+/// </summary>
+public interface IHtmlRenderingService
+{
+    /// <summary>
+    /// Renders a list of bookmarks into a static HTML string using the Explorer Razor component.
+    /// </summary>
+    /// <param name="bookmarks">The bookmarks to render.</param>
+    /// <returns>The generated HTML string.</returns>
+    Task<string> RenderBookmarksAsync(IEnumerable<Raindrop> bookmarks);
+}

--- a/src/Mcp/Ui/IUiCacheService.cs
+++ b/src/Mcp/Ui/IUiCacheService.cs
@@ -1,0 +1,17 @@
+namespace Mcp.Ui;
+
+/// <summary>
+/// Cache service for storing generated UI HTML strings.
+/// </summary>
+public interface IUiCacheService
+{
+    /// <summary>
+    /// Stores the HTML and returns a unique Guid key.
+    /// </summary>
+    string StoreHtml(string html);
+
+    /// <summary>
+    /// Retrieves the HTML by key. Returns null if not found.
+    /// </summary>
+    string? GetHtml(string key);
+}

--- a/src/Mcp/Ui/UiCacheService.cs
+++ b/src/Mcp/Ui/UiCacheService.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace Mcp.Ui;
+
+public class UiCacheService : IUiCacheService
+{
+    private readonly ConcurrentDictionary<string, string> _cache = new();
+
+    public string StoreHtml(string html)
+    {
+        var key = Guid.NewGuid().ToString("N");
+        _cache[key] = html;
+        return key;
+    }
+
+    public string? GetHtml(string key)
+    {
+        _cache.TryGetValue(key, out var html);
+        return html;
+    }
+}

--- a/src/Mcp/Ui/UiResources.cs
+++ b/src/Mcp/Ui/UiResources.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Mcp.Ui;
+
+[McpServerResourceType]
+public class UiResources
+{
+    private readonly IUiCacheService _uiCacheService;
+
+    public UiResources(IUiCacheService uiCacheService)
+    {
+        _uiCacheService = uiCacheService;
+    }
+
+    [McpServerResource(UriTemplate = "ui://raindrop/explorer/{id}", Name = "Bookmark Explorer UI", MimeType = "text/html")]
+    [Description("Returns the dynamically generated HTML grid of bookmarks for a specific visualization request.")]
+    public TextResourceContents GetExplorerUi(string id)
+    {
+        var html = _uiCacheService.GetHtml(id);
+
+        if (html == null)
+        {
+            return new TextResourceContents
+            {
+                Uri = $"ui://raindrop/explorer/{id}",
+                MimeType = "text/html",
+                Text = "<html><body><h2>Error</h2><p>UI visualization not found or expired.</p></body></html>"
+            };
+        }
+
+        return new TextResourceContents
+        {
+            Uri = $"ui://raindrop/explorer/{id}",
+            MimeType = "text/html",
+            Text = html
+        };
+    }
+}

--- a/src/Mcp/Ui/UiTools.cs
+++ b/src/Mcp/Ui/UiTools.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Mcp.Common;
+using Mcp.Raindrops;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Mcp.Ui;
+
+[McpServerToolType]
+public class UiTools
+{
+    private readonly IRaindropsApi _raindropsApi;
+    private readonly IHtmlRenderingService _htmlRenderingService;
+    private readonly IUiCacheService _uiCacheService;
+    private static readonly HashSet<string> ValidSortOptions = new(
+        new[] { "created", "-created", "title", "-title", "domain", "-domain", "sort", "score" }
+    );
+
+    public UiTools(IRaindropsApi raindropsApi, IHtmlRenderingService htmlRenderingService, IUiCacheService uiCacheService)
+    {
+        _raindropsApi = raindropsApi;
+        _htmlRenderingService = htmlRenderingService;
+        _uiCacheService = uiCacheService;
+    }
+
+    [McpServerTool(Name = "visualize_bookmarks", Title = "Visualize Bookmarks"), Description("Searches for bookmarks and displays them in a visual, read-only UI grid for the human user. Use this instead of list_bookmarks when the user wants to visually explore their bookmarks.")]
+    public async Task<CallToolResult> VisualizeBookmarksAsync(
+        [Description("The ID of the collection to retrieve bookmarks from. Use 0 for all, -1 for unsorted, -99 for trash.")] int collectionId,
+        [Description(SearchSyntax.Description)] string? search = null,
+        [Description("Sorting order: '-created' (newest, default), 'created', 'score' (relevance when searching), 'sort', 'title', '-title', 'domain', '-domain'.")] string? sort = null,
+        [Description("Page index starting from 0.")] int? page = null,
+        [Description("How many raindrops per page, up to 50.")] int? perPage = null,
+        [Description("Include bookmarks from nested collections (true/false).")] bool? nested = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (page is < 0)
+            throw new ArgumentOutOfRangeException(nameof(page), page, "Page number cannot be negative.");
+
+        if (perPage is > 50 or < 1)
+            throw new ArgumentOutOfRangeException(nameof(perPage), perPage, "Number of items per page must be between 1 and 50.");
+
+        if (sort is not null)
+        {
+            if (!ValidSortOptions.Contains(sort))
+                throw new ArgumentOutOfRangeException(nameof(sort), sort, $"Valid values are '{string.Join("', '", ValidSortOptions)}'.");
+
+            if (sort == "score" && string.IsNullOrWhiteSpace(search))
+                throw new ArgumentException("Sort 'score' is only allowed when using a search query.", nameof(sort));
+        }
+
+        var response = await _raindropsApi.ListAsync(collectionId, search, sort, page, perPage, nested, cancellationToken);
+
+        var bookmarks = response.Items ?? Array.Empty<Raindrop>();
+
+        var html = await _htmlRenderingService.RenderBookmarksAsync(bookmarks);
+        var guid = _uiCacheService.StoreHtml(html);
+
+        var uri = $"ui://raindrop/explorer/{guid}";
+
+        return new CallToolResult
+        {
+            Content = new List<ContentBlock>
+            {
+                new TextContentBlock { Text = $"Opening the Visual Bookmark Explorer...\nFound {bookmarks.Count} bookmarks." }
+            },
+            Meta = new JsonObject
+            {
+                ["ui"] = new JsonObject { ["ResourceUri"] = uri }
+            }
+        };
+    }
+}

--- a/src/Mcp/Ui/_Imports.razor
+++ b/src/Mcp/Ui/_Imports.razor
@@ -1,0 +1,1 @@
+@using Microsoft.AspNetCore.Components.Web

--- a/tests/Mcp.Tests/RaindropMcp.Tests.csproj
+++ b/tests/Mcp.Tests/RaindropMcp.Tests.csproj
@@ -14,10 +14,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
This PR implements the visual Bookmark Explorer view requested by the user.

- **New Tool (`visualize_bookmarks`)**: Kept separate from `list_bookmarks` to ensure headless reasoning remains intact. Queries the API and forwards data to the HTML renderer.
- **Blazor Integration**: Updated project SDK to `Microsoft.NET.Sdk.Razor` and added `Microsoft.AspNetCore.Components.Web`.
- **UI Service Layer**: Created `IHtmlRenderingService` to encapsulate `HtmlRenderer` dispatch logic without injecting `IServiceProvider` into tools. Created `IUiCacheService` to manage concurrent string caching for the UI artifacts.
- **Razor Component**: Added `Explorer.razor` providing a basic, read-only CSS grid with Pico.css styling via CDN.
- **Dynamic Resource Provider**: Mapped `ui://raindrop/explorer/{id}` to fetch the cached HTML securely.
- **Validation**: Passed integration tests, compiled flawlessly, and visually verified via Playwright screenshot recording.

---
*PR created automatically by Jules for task [17369303663068684374](https://jules.google.com/task/17369303663068684374) started by @g1ddy*