### PR TITLE
feat: Interactive Triage UI with MCP Apps SDK integration

### DIFF
--- a/src/Mcp/Ui/Explorer.razor
+++ b/src/Mcp/Ui/Explorer.razor
@@ -11,6 +11,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bookmark Explorer</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@picocss/pico@2/css/pico.min.css">
+    <script type="module">
+        import { Client } from 'https://cdn.jsdelivr.net/npm/@@modelcontextprotocol/ext-apps/dist/client.js';
+        window.mcpClient = new Client();
+    </script>
     <style>
         .bookmark-grid {
             display: grid;
@@ -41,6 +45,9 @@
         .bookmark-footer {
             margin-top: auto;
             font-size: 0.8rem;
+            display: flex;
+            gap: 10px;
+            align-items: center;
         }
     </style>
 </head>
@@ -71,7 +78,9 @@
                             {
                                 <span> &bull; @bookmark.Domain</span>
                             }
+                            <button class="outline" onclick="window.loadDetails(@bookmark.Id)">Load Details</button>
                         </footer>
+                        <pre id="details-@bookmark.Id" style="display: none;"></pre>
                     </article>
                 }
             }
@@ -81,6 +90,18 @@
             }
         </div>
     </main>
+    <script>
+        window.loadDetails = async (id) => {
+            try {
+                const response = await window.mcpClient.callTool('fetch_bookmark_details', { bookmarkId: id });
+                const detailsBlock = document.getElementById(`details-${id}`);
+                detailsBlock.innerText = JSON.stringify(response.content, null, 2);
+                detailsBlock.style.display = 'block';
+            } catch (err) {
+                console.error("Error loading details:", err);
+            }
+        };
+    </script>
 </body>
 </html>
 

--- a/src/Mcp/Ui/Explorer.razor
+++ b/src/Mcp/Ui/Explorer.razor
@@ -12,8 +12,10 @@
     <title>Bookmark Explorer</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@picocss/pico@2/css/pico.min.css">
     <script type="module">
-        import { Client } from 'https://cdn.jsdelivr.net/npm/@@modelcontextprotocol/ext-apps/dist/client.js';
-        window.mcpClient = new Client();
+        import { App } from 'https://cdn.jsdelivr.net/npm/@@modelcontextprotocol/ext-apps/dist/client.js';
+        const app = new App();
+        app.connect();
+        window.mcpApp = app;
     </script>
     <style>
         .bookmark-grid {
@@ -93,7 +95,7 @@
     <script>
         window.loadDetails = async (id) => {
             try {
-                const response = await window.mcpClient.callTool('fetch_bookmark_details', { bookmarkId: id });
+                const response = await window.mcpApp.callServerTool({ name: 'fetch_bookmark_details', arguments: { bookmarkId: id } });
                 const detailsBlock = document.getElementById(`details-${id}`);
                 detailsBlock.innerText = JSON.stringify(response.content, null, 2);
                 detailsBlock.style.display = 'block';

--- a/src/Mcp/Ui/UiTools.cs
+++ b/src/Mcp/Ui/UiTools.cs
@@ -75,9 +75,9 @@ public class UiTools
         };
     }
 
-    [McpServerTool(Name = "fetch_bookmark_details", Title = "Fetch Bookmark Details"), Description("Fetches extended metadata for a specific bookmark. Used by the UI.")]
+    [McpServerTool(Name = "fetch_bookmark_details", Title = "Fetch Bookmark Details", ReadOnly = true, Destructive = false, Idempotent = true), Description("Fetches extended metadata for a specific bookmark. Used by the UI.")]
     public async Task<CallToolResult> FetchBookmarkDetailsAsync(
-        [Description("ID of the bookmark to retrieve")] int bookmarkId,
+        [Description("ID of the bookmark to retrieve")] long bookmarkId,
         CancellationToken cancellationToken = default)
     {
         var rawData = await _raindropsApi.GetAsync(bookmarkId, cancellationToken);

--- a/src/Mcp/Ui/UiTools.cs
+++ b/src/Mcp/Ui/UiTools.cs
@@ -74,4 +74,20 @@ public class UiTools
             }
         };
     }
+
+    [McpServerTool(Name = "fetch_bookmark_details", Title = "Fetch Bookmark Details"), Description("Fetches extended metadata for a specific bookmark. Used by the UI.")]
+    public async Task<CallToolResult> FetchBookmarkDetailsAsync(
+        [Description("ID of the bookmark to retrieve")] int bookmarkId,
+        CancellationToken cancellationToken = default)
+    {
+        var rawData = await _raindropsApi.GetAsync(bookmarkId, cancellationToken);
+        var jsonText = System.Text.Json.JsonSerializer.Serialize(rawData);
+        return new CallToolResult
+        {
+            Content = new List<ContentBlock>
+            {
+                new TextContentBlock { Text = jsonText }
+            }
+        };
+    }
 }


### PR DESCRIPTION
This PR introduces the Interactive Triage feature bridging the UI and backend logic.
It integrates the `@modelcontextprotocol/ext-apps/dist/client.js` client in `Explorer.razor` to interactively call backend tools.
Added a "Load Details" button rendering retrieved metadata (JSON format) directly in a hidden `<pre>` tag dynamically. 
The new `fetch_bookmark_details` tool exposes bookmark lookup functionality logically under UI tools by reusing the underlying `IRaindropsApi`.

---
*PR created automatically by Jules for task [5750372010064575001](https://jules.google.com/task/5750372010064575001) started by @g1ddy*