### PR TITLE
Upgrade NuGet package versions for runtime, tests, and Refit/ModelContextProtocol

### DIFF
--- a/src/Mcp/RaindropMcp.csproj
+++ b/src/Mcp/RaindropMcp.csproj
@@ -52,14 +52,15 @@
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.11" />
     <!-- <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.3.0-preview.3" /> -->
-    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="11.0.1" />
+    <PackageReference Include="ModelContextProtocol" Version="2.2.0" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="15.0.0" />
+    <PackageReference Include="Refit.Reflection" Version="15.0.0" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/tests/Mcp.Tests/RaindropMcp.Tests.csproj
+++ b/tests/Mcp.Tests/RaindropMcp.Tests.csproj
@@ -14,11 +14,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
### Motivation

- Bring several dependencies up to newer patch/minor versions to pick up fixes and compatibility with the target SDK.

### Description

- Updated package versions in `src/Mcp/RaindropMcp.csproj` for `Microsoft.AspNetCore.Components.Web`, `Microsoft.Extensions.*` and related packages from `10.0.9/10.0.10` to `10.0.11`.
- Upgraded `ModelContextProtocol` from `1.4.1` to `2.2.0` and bumped `Refit.HttpClientFactory` from `11.0.1` to `15.0.0` while adding `Refit.Reflection` `15.0.0`.
- Updated test project package versions in `tests/Mcp.Tests/RaindropMcp.Tests.csproj` for `Microsoft.Extensions.*` to `10.0.11` and `Microsoft.NET.Test.Sdk` to `18.8.1`.
- Kept existing MSBuild target `InjectVersionIntoServerJson` and other project settings unchanged while adjusting package references.

### Testing

- Ran `dotnet restore` and `dotnet build` for the solution and the projects, and the build completed successfully.
- Ran unit tests with `dotnet test` targeting `tests/Mcp.Tests` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d6c2023e88330a1f740c1e0d136ba)