### PR TITLE
Deterministic collection suggestion service; remove LLM sampling from suggestion workflow

### DIFF
--- a/docs/DETERMINISTIC_COLLECTION_SUGGESTIONS.md
+++ b/docs/DETERMINISTIC_COLLECTION_SUGGESTIONS.md
@@ -1,0 +1,80 @@
+# Deterministic Collection Suggestions
+
+## Purpose
+
+The `suggest_collection_for_bookmark` workflow historically used MCP Sampling to ask the client model to rank collection titles. Sampling is deprecated as of MCP specification version 2026-07-28, varies in availability between clients, and makes ranking difficult to reproduce or evaluate.
+
+This document describes the migration to a deterministic, server-owned classifier. The goal is to rank up to three collections from bookmark and library metadata, keep the existing user confirmation step, and avoid generative inference.
+
+## Roadmap
+
+### Phase 1: deterministic lexical and structured signals — implemented
+
+Phase 1 builds a per-user in-memory index from the existing bookmark library and ranks collections using three explainable signals:
+
+| Signal | Weight | Description |
+| --- | ---: | --- |
+| TF-IDF cosine similarity | 60% | Compares the query bookmark with a collection document assembled from its title, description, and historical bookmarks. |
+| Tag Jaccard similarity | 20% | Measures overlap between the query's tags and the distinct tags historically used in a collection. |
+| Domain affinity | 20% | Measures the fraction of bookmarks from the query domain that belong to a collection. |
+
+Bookmark terms include the title, link, excerpt, note, type, domain, and normalized tags. Tokens are Unicode letter/number sequences, lower-cased invariantly, with one-character tokens omitted. Collection title and description supply useful cold-start terms even when a collection contains no bookmarks.
+
+The index is built lazily on the first suggestion request, cached by Raindrop API token, and shared across concurrent requests. Failed builds are not cached. It is invalidated after successful collection mutations and after a bookmark is moved by the suggestion workflow. Index construction fetches bookmark pages of 50 items and stops at the end of the result set or if an API page repeats only bookmark IDs already observed.
+
+Ranking is exact rather than approximate. Results are ordered by descending score and then collection ID, providing a stable tie-break. Zero-score candidates are omitted; the tool returns an unsuccessful result when no relevant collection can be found. The top three positive candidates continue through MCP Elicitation so that the user, not the classifier, selects the destination.
+
+#### Phase 1 limitations
+
+- The weights are initial defaults rather than values learned from evaluation data.
+- Term frequency can over-emphasize repeated generic URL or text tokens.
+- One aggregate document can blur collections containing several unrelated topics.
+- The index is process-local and must be rebuilt after a restart.
+- External bookmark moves do not immediately invalidate the index; a restart or a successful mutation through this server rebuilds it.
+- Only top-level collections are candidates, preserving the previous tool behavior.
+
+### Phase 2: optional vector embeddings
+
+Add an optional `IEmbeddingGenerator<string, Embedding<float>>` implementation through `Microsoft.Extensions.AI`.
+
+1. Format bookmark metadata into a stable canonical string.
+2. Generate and normalize one embedding per historical bookmark.
+3. Maintain one normalized centroid per collection.
+4. Compute exact cosine similarity between a query vector and collection centroids.
+5. Blend semantic similarity with the Phase 1 tag, domain, and lexical scores.
+6. Pin the model identifier, revision, dimensions, tokenizer/input format, and normalization strategy in the index version.
+7. Fall back to Phase 1 when no embedding generator is configured or embedding generation fails.
+
+Before rollout, compare Phase 2 against the Phase 1 baseline. Do not retain embeddings unless top-three recall or accepted-suggestion accuracy improves materially. For privacy-sensitive deployments, evaluate a pinned local ONNX embedding model rather than transmitting bookmark content to a hosted provider.
+
+### Phase 3: advanced retrieval and personalization
+
+Add complexity only when measurements justify it:
+
+- Use two to five centroids for large, heterogeneous collections.
+- Optionally rerank using exact K-nearest-neighbor search over historical bookmark vectors.
+- Return explanation data such as matching tags, domain history, and representative neighboring bookmarks.
+- Persist a versioned index in SQLite or a binary cache.
+- Incrementally update statistics and centroids on create, update, move, and delete events.
+- Add approximate nearest-neighbor indexing only if exact search becomes a measured bottleneck.
+- Learn or tune hybrid weights per user after enough confirmed choices are available.
+
+## Evaluation plan
+
+Treat the current collection of each historical bookmark as its label. When evaluating an item, exclude that item from the training index to prevent leakage.
+
+Prefer a chronological split—older bookmarks for training and newer bookmarks for evaluation—to approximate future suggestions. Track:
+
+- top-1 accuracy;
+- top-3 recall;
+- mean reciprocal rank;
+- coverage above a confidence threshold;
+- accuracy at accepted confidence;
+- per-collection accuracy to identify large-collection bias;
+- user acceptance rate for online suggestions.
+
+Evaluate rules/domain affinity, TF-IDF, embeddings, and the hybrid independently. The more complex phase should be adopted only when it improves the measured result.
+
+## Operational and privacy notes
+
+The Phase 1 index remains in memory and does not add a new persistent copy of bookmark content. It is partitioned using the configured API token as the existing application cache key, but the token is not included in suggestion results. Future persisted or hosted embedding implementations must document retention, encryption, tenant isolation, provider data handling, and index deletion behavior.

--- a/src/Mcp/Collections/CollectionsTools.cs
+++ b/src/Mcp/Collections/CollectionsTools.cs
@@ -1,9 +1,9 @@
 using System.Buffers;
 using System.ComponentModel;
-using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 using Mcp.Common;
+using Mcp.Collections.Suggestions;
 using Mcp.Raindrops;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
@@ -11,15 +11,18 @@ using ModelContextProtocol.Server;
 namespace Mcp.Collections;
 
 [McpServerToolType]
-public class CollectionsTools(ICollectionsApi api, IRaindropsApi raindropsApi, IRaindropCacheService cacheService, IOptions<RaindropOptions> options) :
+public class CollectionsTools(
+    ICollectionsApi api,
+    IRaindropsApi raindropsApi,
+    IRaindropCacheService cacheService,
+    ICollectionSuggestionService suggestionService,
+    IOptions<RaindropOptions> options) :
     RaindropToolBase<ICollectionsApi>(api)
 {
-    private static readonly char[] _separators = ['|', '\n'];
-    private static readonly char[] _trimChars = ['-', '*', ' ', '\'', '"', '.'];
     private readonly IRaindropsApi _raindropsApi = raindropsApi;
     private readonly IRaindropCacheService _cacheService = cacheService;
+    private readonly ICollectionSuggestionService _suggestionService = suggestionService;
     private readonly string _cacheKey = options.Value.ApiToken;
-    private const int DefaultMaxTokens = 1000;
 
     private Task<ItemsResponse<Collection>> GetCachedCollectionsAsync(CancellationToken cancellationToken)
         => _cacheService.GetCollectionsAsync(_cacheKey, Api.ListAsync, cancellationToken);
@@ -45,6 +48,7 @@ public class CollectionsTools(ICollectionsApi api, IRaindropsApi raindropsApi, I
         if (response.Result)
         {
             await _cacheService.InvalidateCollectionsAsync(_cacheKey, cancellationToken);
+            _suggestionService.Invalidate();
         }
         return response;
     }
@@ -59,6 +63,7 @@ public class CollectionsTools(ICollectionsApi api, IRaindropsApi raindropsApi, I
         if (response.Result)
         {
             await _cacheService.InvalidateCollectionsAsync(_cacheKey, cancellationToken);
+            _suggestionService.Invalidate();
         }
         return response;
     }
@@ -71,6 +76,7 @@ public class CollectionsTools(ICollectionsApi api, IRaindropsApi raindropsApi, I
         if (response.Result)
         {
             await _cacheService.InvalidateCollectionsAsync(_cacheKey, cancellationToken);
+            _suggestionService.Invalidate();
         }
         return response;
     }
@@ -167,6 +173,7 @@ public class CollectionsTools(ICollectionsApi api, IRaindropsApi raindropsApi, I
         if (response.Result)
         {
             await _cacheService.InvalidateCollectionsAsync(_cacheKey, cancellationToken);
+            _suggestionService.Invalidate();
         }
         return response;
     }
@@ -196,98 +203,23 @@ public class CollectionsTools(ICollectionsApi api, IRaindropsApi raindropsApi, I
         {
             return new SuccessResponse(false);
         }
-        var collectionTitles = new Dictionary<string, Collection>(StringComparer.OrdinalIgnoreCase);
-        var promptBuilder = new StringBuilder();
-
-        var filteredCollections = collectionsResponse.Items
+        var candidateCollections = collectionsResponse.Items
             .Where(c => !string.IsNullOrEmpty(c.Title))
             .Where(c => c.Parent == null) // Filter out child collections
-            .OrderBy(c => c.Count)
-            .Take(25);
-
-        foreach (var c in filteredCollections)
-        {
-            // We've already filtered for null/empty title above
-            var title = Sanitize(c.Title!);
-            if (collectionTitles.TryAdd(title, c))
-            {
-                if (promptBuilder.Length > 0)
-                {
-                    promptBuilder.Append('\n');
-                }
-                promptBuilder.Append("- ");
-                promptBuilder.Append(title);
-            }
-        }
+            .ToList();
+        var collectionTitles = candidateCollections
+            .GroupBy(c => Sanitize(c.Title), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
 
         if (collectionTitles.Count == 0)
         {
             return new SuccessResponse(false);
         }
+        candidateCollections = collectionTitles.Values.ToList();
 
-        // 3. Use the LLM to get the top 3 suggestions
-        var prompt = $"""
-            Given the following bookmark:
-            - Title: {Sanitize(bookmark.Title)}
-            - URL: {Sanitize(bookmark.Link)}
-            - Excerpt: {Sanitize(bookmark.Excerpt)}
-
-            And the following list of collections:
-            {promptBuilder}
-
-            Please suggest the top 3 most relevant collections for this bookmark.
-            Return ONLY a pipe-separated list of the collection titles, exactly as they appear in the list above.
-            Do not include any explanations, numbering, or bullet points.
-            Example: Title1 | Title2 | Title3
-        """;
-
-        var sampleRequest = new CreateMessageRequestParams
-        {
-            MaxTokens = DefaultMaxTokens,
-            Messages =
-            [
-                new SamplingMessage
-                {
-                    Role = Role.User,
-                    Content = [new TextContentBlock { Text = prompt }]
-                }
-            ]
-        };
-
-        var llmResponse = await server.SampleAsync(sampleRequest, cancellationToken);
-        if (llmResponse?.Content?.FirstOrDefault() is not TextContentBlock textContent || string.IsNullOrWhiteSpace(textContent.Text))
-        {
-            return new SuccessResponse(false);
-        }
-
-        var suggestedTitles = new List<string>(3);
-        var altLookup = collectionTitles.GetAlternateLookup<ReadOnlySpan<char>>();
-        var textSpan = textContent.Text.AsSpan();
-
-        foreach (var range in textSpan.SplitAny(_separators))
-        {
-            var span = textSpan[range].Trim(_trimChars);
-            if (span.IsEmpty) continue;
-
-            if (altLookup.TryGetValue(span, out var collection))
-            {
-                bool isDistinct = true;
-                foreach (var t in suggestedTitles)
-                {
-                    if (span.SequenceEqual(t.AsSpan()))
-                    {
-                        isDistinct = false;
-                        break;
-                    }
-                }
-
-                if (isDistinct) // Ensure distinct
-                {
-                    suggestedTitles.Add(span.ToString());
-                    if (suggestedTitles.Count == 3) break;
-                }
-            }
-        }
+        // 3. Rank collections using deterministic lexical, tag, and domain signals.
+        var suggestions = await _suggestionService.SuggestAsync(bookmark, candidateCollections, 3, cancellationToken);
+        var suggestedTitles = suggestions.Select(suggestion => Sanitize(suggestion.Collection.Title)).ToList();
 
         if (suggestedTitles.Count == 0)
         {
@@ -337,6 +269,7 @@ public class CollectionsTools(ICollectionsApi api, IRaindropsApi raindropsApi, I
         if (updateResponse.Result)
         {
             await _cacheService.InvalidateCollectionsAsync(_cacheKey, cancellationToken);
+            _suggestionService.Invalidate();
         }
         return new SuccessResponse(updateResponse.Result);
     }

--- a/src/Mcp/Collections/Suggestions/CollectionSuggestionIndexCache.cs
+++ b/src/Mcp/Collections/Suggestions/CollectionSuggestionIndexCache.cs
@@ -1,0 +1,47 @@
+using System.Collections.Concurrent;
+
+namespace Mcp.Collections.Suggestions;
+
+internal sealed class CollectionSuggestionIndexCache
+{
+    private readonly ConcurrentDictionary<string, Lazy<Task<CollectionSuggestionIndex>>> _indexes = [];
+
+    public Task<CollectionSuggestionIndex> GetOrCreateAsync(
+        string cacheKey,
+        Func<Task<CollectionSuggestionIndex>> factory)
+    {
+        var lazy = _indexes.GetOrAdd(
+            cacheKey,
+            _ => new Lazy<Task<CollectionSuggestionIndex>>(factory, LazyThreadSafetyMode.ExecutionAndPublication));
+
+        return AwaitAndRemoveFaultedAsync(cacheKey, lazy);
+    }
+
+    public void Invalidate(string cacheKey) => _indexes.TryRemove(cacheKey, out _);
+
+    private async Task<CollectionSuggestionIndex> AwaitAndRemoveFaultedAsync(
+        string cacheKey,
+        Lazy<Task<CollectionSuggestionIndex>> lazy)
+    {
+        try
+        {
+            return await lazy.Value;
+        }
+        catch
+        {
+            _indexes.TryRemove(new KeyValuePair<string, Lazy<Task<CollectionSuggestionIndex>>>(cacheKey, lazy));
+            throw;
+        }
+    }
+}
+
+internal sealed record CollectionSuggestionIndex(
+    IReadOnlyDictionary<int, CollectionFeatures> Collections,
+    IReadOnlyDictionary<string, int> DocumentFrequencies,
+    int DocumentCount,
+    IReadOnlyDictionary<string, int> DomainTotals);
+
+internal sealed record CollectionFeatures(
+    IReadOnlyDictionary<string, int> Terms,
+    IReadOnlySet<string> Tags,
+    IReadOnlyDictionary<string, int> Domains);

--- a/src/Mcp/Collections/Suggestions/CollectionSuggestionService.cs
+++ b/src/Mcp/Collections/Suggestions/CollectionSuggestionService.cs
@@ -1,0 +1,206 @@
+using System.Text.RegularExpressions;
+using Mcp.Raindrops;
+using Microsoft.Extensions.Options;
+
+namespace Mcp.Collections.Suggestions;
+
+internal sealed partial class CollectionSuggestionService(
+    IRaindropsApi raindropsApi,
+    CollectionSuggestionIndexCache cache,
+    IOptions<RaindropOptions> options) : ICollectionSuggestionService
+{
+    private const int PageSize = 50;
+    private const double LexicalWeight = 0.60;
+    private const double TagWeight = 0.20;
+    private const double DomainWeight = 0.20;
+    private static readonly HashSet<string> _stopWords = new(StringComparer.Ordinal)
+    {
+        "http", "https", "www"
+    };
+    private readonly string _cacheKey = options.Value.ApiToken;
+
+    public async Task<IReadOnlyList<CollectionSuggestion>> SuggestAsync(
+        Raindrop bookmark,
+        IReadOnlyCollection<Collection> collections,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(bookmark);
+        ArgumentNullException.ThrowIfNull(collections);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
+
+        var candidates = collections
+            .Where(collection => collection.Id > 0 && !string.IsNullOrWhiteSpace(collection.Title))
+            .ToDictionary(collection => collection.Id);
+        if (candidates.Count == 0)
+            return [];
+
+        var index = await cache.GetOrCreateAsync(
+            _cacheKey,
+            () => BuildIndexAsync(candidates, cancellationToken));
+        var queryTerms = TokenizeBookmark(bookmark);
+        var queryTags = NormalizeTags(bookmark.Tags);
+        var queryDomain = Normalize(bookmark.Domain);
+
+        return candidates.Values
+            .Select(collection => new CollectionSuggestion(
+                collection,
+                Score(collection.Id, queryTerms, queryTags, queryDomain, index)))
+            .Where(suggestion => suggestion.Score > 0)
+            .OrderByDescending(suggestion => suggestion.Score)
+            .ThenBy(suggestion => suggestion.Collection.Id)
+            .Take(limit)
+            .ToList();
+    }
+
+    public void Invalidate() => cache.Invalidate(_cacheKey);
+
+    private async Task<CollectionSuggestionIndex> BuildIndexAsync(
+        IReadOnlyDictionary<int, Collection> candidates,
+        CancellationToken cancellationToken)
+    {
+        var terms = candidates.ToDictionary(
+            pair => pair.Key,
+            pair => CountTerms(Tokenize(pair.Value.Title, pair.Value.Description)));
+        var tags = candidates.Keys.ToDictionary(id => id, _ => new HashSet<string>(StringComparer.Ordinal));
+        var domains = candidates.Keys.ToDictionary(id => id, _ => new Dictionary<string, int>(StringComparer.Ordinal));
+        var domainTotals = new Dictionary<string, int>(StringComparer.Ordinal);
+        var seenBookmarkIds = new HashSet<long>();
+
+        for (var page = 0; ; page++)
+        {
+            var response = await raindropsApi.ListAsync(0, null, null, page, PageSize, true, cancellationToken);
+            if (response.Result != true || response.Items is null)
+                throw new InvalidOperationException($"Raindrop did not return bookmark page {page} while building the suggestion index.");
+
+            var newBookmarks = 0;
+            foreach (var bookmark in response.Items)
+            {
+                if (!seenBookmarkIds.Add(bookmark.Id))
+                    continue;
+                newBookmarks++;
+
+                if (bookmark.Collection is not { Id: var collectionId } || !candidates.ContainsKey(collectionId))
+                    continue;
+
+                AddTermCounts(terms[collectionId], TokenizeBookmark(bookmark));
+                tags[collectionId].UnionWith(NormalizeTags(bookmark.Tags));
+
+                var domain = Normalize(bookmark.Domain);
+                if (domain is null)
+                    continue;
+                Increment(domains[collectionId], domain);
+                Increment(domainTotals, domain);
+            }
+
+            if (response.Items.Count < PageSize || newBookmarks == 0)
+                break;
+        }
+
+        var documentFrequencies = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var documentTerms in terms.Values)
+            foreach (var term in documentTerms.Keys)
+                Increment(documentFrequencies, term);
+
+        var features = candidates.Keys.ToDictionary(
+            id => id,
+            id => new CollectionFeatures(terms[id], tags[id], domains[id]));
+        return new CollectionSuggestionIndex(features, documentFrequencies, candidates.Count, domainTotals);
+    }
+
+    private static double Score(
+        int collectionId,
+        IReadOnlyDictionary<string, int> queryTerms,
+        IReadOnlySet<string> queryTags,
+        string? queryDomain,
+        CollectionSuggestionIndex index)
+    {
+        if (!index.Collections.TryGetValue(collectionId, out var features))
+            return 0;
+
+        var lexical = TfIdfCosine(queryTerms, features.Terms, index.DocumentFrequencies, index.DocumentCount);
+        var tag = Jaccard(queryTags, features.Tags);
+        var domain = queryDomain is not null && index.DomainTotals.TryGetValue(queryDomain, out var total)
+            ? (double)features.Domains.GetValueOrDefault(queryDomain) / total
+            : 0;
+        return LexicalWeight * lexical + TagWeight * tag + DomainWeight * domain;
+    }
+
+    private static double TfIdfCosine(
+        IReadOnlyDictionary<string, int> left,
+        IReadOnlyDictionary<string, int> right,
+        IReadOnlyDictionary<string, int> documentFrequencies,
+        int documentCount)
+    {
+        double dot = 0, leftMagnitude = 0, rightMagnitude = 0;
+        foreach (var (term, count) in left)
+        {
+            var weight = count * InverseDocumentFrequency(term, documentFrequencies, documentCount);
+            leftMagnitude += weight * weight;
+            if (right.TryGetValue(term, out var rightCount))
+                dot += weight * rightCount * InverseDocumentFrequency(term, documentFrequencies, documentCount);
+        }
+
+        foreach (var (term, count) in right)
+        {
+            var weight = count * InverseDocumentFrequency(term, documentFrequencies, documentCount);
+            rightMagnitude += weight * weight;
+        }
+
+        return leftMagnitude == 0 || rightMagnitude == 0 ? 0 : dot / Math.Sqrt(leftMagnitude * rightMagnitude);
+    }
+
+    private static double InverseDocumentFrequency(
+        string term,
+        IReadOnlyDictionary<string, int> documentFrequencies,
+        int documentCount) =>
+        Math.Log((documentCount + 1d) / (documentFrequencies.GetValueOrDefault(term) + 1d)) + 1d;
+
+    private static double Jaccard(IReadOnlySet<string> left, IReadOnlySet<string> right)
+    {
+        if (left.Count == 0 || right.Count == 0)
+            return 0;
+        var intersection = left.Count(right.Contains);
+        return (double)intersection / (left.Count + right.Count - intersection);
+    }
+
+    private static Dictionary<string, int> TokenizeBookmark(Raindrop bookmark) =>
+        CountTerms(Tokenize(bookmark.Title, bookmark.Link, bookmark.Excerpt, bookmark.Note, bookmark.Type, bookmark.Domain)
+            .Concat(NormalizeTags(bookmark.Tags)));
+
+    private static IEnumerable<string> Tokenize(params string?[] values) =>
+        values.Where(value => !string.IsNullOrWhiteSpace(value))
+            .SelectMany(value => TokenRegex().Matches(value!).Select(match => match.Value.ToLowerInvariant()))
+            .Where(term => term.Length > 1 && !_stopWords.Contains(term));
+
+    private static HashSet<string> NormalizeTags(IEnumerable<string>? values) =>
+        values?.Select(Normalize).OfType<string>().ToHashSet(StringComparer.Ordinal) ?? [];
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim().ToLowerInvariant();
+
+    private static Dictionary<string, int> CountTerms(IEnumerable<string> values)
+    {
+        var result = new Dictionary<string, int>(StringComparer.Ordinal);
+        AddTerms(result, values);
+        return result;
+    }
+
+    private static void AddTerms(Dictionary<string, int> terms, IEnumerable<string> values)
+    {
+        foreach (var value in values)
+            Increment(terms, value);
+    }
+
+    private static void AddTermCounts(Dictionary<string, int> terms, IReadOnlyDictionary<string, int> values)
+    {
+        foreach (var (term, count) in values)
+            terms[term] = terms.GetValueOrDefault(term) + count;
+    }
+
+    private static void Increment(Dictionary<string, int> values, string key) =>
+        values[key] = values.GetValueOrDefault(key) + 1;
+
+    [GeneratedRegex(@"[\p{L}\p{Nd}]+", RegexOptions.CultureInvariant)]
+    private static partial Regex TokenRegex();
+}

--- a/src/Mcp/Collections/Suggestions/ICollectionSuggestionService.cs
+++ b/src/Mcp/Collections/Suggestions/ICollectionSuggestionService.cs
@@ -1,0 +1,16 @@
+using Mcp.Raindrops;
+
+namespace Mcp.Collections.Suggestions;
+
+public interface ICollectionSuggestionService
+{
+    Task<IReadOnlyList<CollectionSuggestion>> SuggestAsync(
+        Raindrop bookmark,
+        IReadOnlyCollection<Collection> collections,
+        int limit,
+        CancellationToken cancellationToken);
+
+    void Invalidate();
+}
+
+public sealed record CollectionSuggestion(Collection Collection, double Score);

--- a/src/Mcp/RaindropServiceCollectionExtensions.cs
+++ b/src/Mcp/RaindropServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Refit;
 using System.Net.Http.Headers;
 using Mcp.Common;
 using Mcp.Collections;
+using Mcp.Collections.Suggestions;
 using Mcp.Raindrops;
 using Mcp.Highlights;
 using Mcp.Filters;
@@ -42,6 +43,8 @@ public static class RaindropServiceCollectionExtensions
 
         services.AddSingleton<RaindropClientConfig>();
         services.AddSingleton<IRaindropCacheService, RaindropCacheService>();
+        services.AddSingleton<CollectionSuggestionIndexCache>();
+        services.AddTransient<ICollectionSuggestionService, CollectionSuggestionService>();
         services.AddTransient<ILibraryAnalyticsService, LibraryAnalyticsService>();
 
         var settings = new RefitSettings

--- a/src/Mcp/Raindrops/RaindropsTools.cs
+++ b/src/Mcp/Raindrops/RaindropsTools.cs
@@ -3,16 +3,22 @@ using ModelContextProtocol.Server;
 using Mcp.Common;
 using Mcp.Tags;
 using Mcp.Collections;
+using Mcp.Collections.Suggestions;
 
 using Microsoft.Extensions.Options;
 
 namespace Mcp.Raindrops;
 
 [McpServerToolType]
-public class RaindropsTools(IRaindropsApi api, IRaindropCacheService cacheService, IOptions<RaindropOptions> options) :
+public class RaindropsTools(
+    IRaindropsApi api,
+    IRaindropCacheService cacheService,
+    ICollectionSuggestionService suggestionService,
+    IOptions<RaindropOptions> options) :
     RaindropToolBase<IRaindropsApi>(api)
 {
     private readonly IRaindropCacheService _cacheService = cacheService;
+    private readonly ICollectionSuggestionService _suggestionService = suggestionService;
     private readonly string _cacheKey = options.Value.ApiToken;
     private static readonly HashSet<string> ValidSortOptions = new(
         new[] { "created", "-created", "title", "-title", "domain", "-domain", "sort", "score" }
@@ -27,7 +33,7 @@ public class RaindropsTools(IRaindropsApi api, IRaindropCacheService cacheServic
         var response = await Api.CreateAsync(payload, cancellationToken);
         if (response.Result)
         {
-            await _cacheService.InvalidateAllAsync(_cacheKey, cancellationToken);
+            await InvalidateCachesAsync(cancellationToken);
         }
         return response;
     }
@@ -49,7 +55,7 @@ public class RaindropsTools(IRaindropsApi api, IRaindropCacheService cacheServic
         var response = await Api.UpdateAsync(id, payload, cancellationToken);
         if (response.Result)
         {
-            await _cacheService.InvalidateAllAsync(_cacheKey, cancellationToken);
+            await InvalidateCachesAsync(cancellationToken);
         }
         return response;
     }
@@ -62,7 +68,7 @@ public class RaindropsTools(IRaindropsApi api, IRaindropCacheService cacheServic
         var response = await Api.DeleteAsync(id, cancellationToken);
         if (response.Result)
         {
-            await _cacheService.InvalidateAllAsync(_cacheKey, cancellationToken);
+            await InvalidateCachesAsync(cancellationToken);
         }
         return response;
     }
@@ -157,7 +163,7 @@ public class RaindropsTools(IRaindropsApi api, IRaindropCacheService cacheServic
         // Only invalidate if we actually created at least one item, even if not overall success
         if (allItems.Count > 0)
         {
-            await _cacheService.InvalidateAllAsync(_cacheKey, cancellationToken);
+            await InvalidateCachesAsync(cancellationToken);
         }
 
         return new ItemsResponse<Raindrop>(overallResult, allItems);
@@ -175,8 +181,14 @@ public class RaindropsTools(IRaindropsApi api, IRaindropCacheService cacheServic
         var response = await Api.UpdateManyAsync(collectionId, update, nested, search, cancellationToken);
         if (response.Result)
         {
-            await _cacheService.InvalidateAllAsync(_cacheKey, cancellationToken);
+            await InvalidateCachesAsync(cancellationToken);
         }
         return response;
+    }
+
+    private async Task InvalidateCachesAsync(CancellationToken cancellationToken)
+    {
+        _suggestionService.Invalidate();
+        await _cacheService.InvalidateAllAsync(_cacheKey, cancellationToken);
     }
 }

--- a/tests/Mcp.Benchmarks/CollectionsToolsBenchmark.cs
+++ b/tests/Mcp.Benchmarks/CollectionsToolsBenchmark.cs
@@ -1,5 +1,6 @@
 using BenchmarkDotNet.Attributes;
 using Mcp.Collections;
+using Mcp.Collections.Suggestions;
 using Mcp.Raindrops;
 using Mcp.Common;
 using ModelContextProtocol.Server;
@@ -23,6 +24,7 @@ public class CollectionsToolsBenchmark : RaindropBenchmarkBase
     private Mock<McpServer> _mcpServerMock = null!;
     private Mock<ICollectionsApi> _collectionsApiMock = null!;
     private Mock<IRaindropsApi> _raindropsApiMock = null!;
+    private Mock<ICollectionSuggestionService> _suggestionServiceMock = null!;
     private List<Collection> _largeCollectionList = null!;
 
     [Params(100, 1000)]
@@ -35,6 +37,7 @@ public class CollectionsToolsBenchmark : RaindropBenchmarkBase
         _collectionsApiMock = new Mock<ICollectionsApi>();
         _raindropsApiMock = new Mock<IRaindropsApi>();
         _mcpServerMock = new Mock<McpServer>();
+        _suggestionServiceMock = new Mock<ICollectionSuggestionService>();
 
         // Generate a large list of collections
         _largeCollectionList = new List<Collection>();
@@ -59,26 +62,39 @@ public class CollectionsToolsBenchmark : RaindropBenchmarkBase
             .ReturnsAsync(new ItemsResponse<Collection>(true, _largeCollectionList));
 
         // Setup McpServer
-         _mcpServerMock.Setup(x => x.ClientCapabilities)
+        _mcpServerMock.Setup(x => x.ClientCapabilities)
             .Returns(new ClientCapabilities
             {
-                Sampling = new SamplingCapability(),
                 Elicitation = new ElicitationCapability { Form = new FormElicitationCapability() }
             });
 
-        // Mock SendRequestAsync to return a valid response
-        var llmResponse = new CreateMessageResult
+        _suggestionServiceMock.Setup(x => x.SuggestAsync(
+                It.IsAny<Raindrop>(),
+                It.IsAny<IReadOnlyCollection<Collection>>(),
+                3,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new CollectionSuggestion(new Collection { Id = 1, Title = "Collection 1" }, 1),
+                new CollectionSuggestion(new Collection { Id = 2, Title = "Collection 2" }, 0.9),
+                new CollectionSuggestion(new Collection { Id = 3, Title = "Collection 3" }, 0.8)
+            ]);
+
+        var elicitResult = new ElicitResult
         {
-            Role = Role.Assistant,
-            Content = [new TextContentBlock { Text = "Collection 1 | Collection 2 | Collection 3" }],
-            Model = "test-model"
+            Action = "decline"
         };
 
         _mcpServerMock.Setup(x => x.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
-             .ReturnsAsync(new JsonRpcResponse { Result = JsonSerializer.SerializeToNode(llmResponse) });
+             .ReturnsAsync(new JsonRpcResponse { Result = JsonSerializer.SerializeToNode(elicitResult) });
 
         var options = Options.Create(new RaindropOptions { ApiToken = "benchmark-token" });
-        _tools = new CollectionsTools(_collectionsApiMock.Object, _raindropsApiMock.Object, new RaindropCacheService(), options);
+        _tools = new CollectionsTools(
+            _collectionsApiMock.Object,
+            _raindropsApiMock.Object,
+            new RaindropCacheService(),
+            _suggestionServiceMock.Object,
+            options);
     }
 
     [Benchmark]

--- a/tests/Mcp.Benchmarks/MergeCollectionsBenchmark.cs
+++ b/tests/Mcp.Benchmarks/MergeCollectionsBenchmark.cs
@@ -1,5 +1,6 @@
 using BenchmarkDotNet.Attributes;
 using Mcp.Collections;
+using Mcp.Collections.Suggestions;
 using Mcp.Raindrops;
 using Mcp.Common;
 using Moq;
@@ -37,7 +38,12 @@ public class MergeCollectionsBenchmark : RaindropBenchmarkBase
             .ReturnsAsync(new SuccessResponse(true));
 
         var options = Options.Create(new RaindropOptions { ApiToken = "benchmark-token" });
-        _tools = new CollectionsTools(_collectionsApiMock.Object, _raindropsApiMock.Object, new RaindropCacheService(), options);
+        _tools = new CollectionsTools(
+            _collectionsApiMock.Object,
+            _raindropsApiMock.Object,
+            new RaindropCacheService(),
+            Mock.Of<ICollectionSuggestionService>(),
+            options);
     }
 
     [Benchmark]

--- a/tests/Mcp.Benchmarks/RaindropsToolsBenchmark.cs
+++ b/tests/Mcp.Benchmarks/RaindropsToolsBenchmark.cs
@@ -1,6 +1,7 @@
 using BenchmarkDotNet.Attributes;
 using Mcp.Raindrops;
 using Mcp.Common;
+using Mcp.Collections.Suggestions;
 using Moq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,7 +29,11 @@ public class RaindropsToolsBenchmark : RaindropBenchmarkBase
             .ReturnsAsync(new ItemsResponse<Raindrop>(true, new List<Raindrop>()));
 
         var options = Options.Create(new RaindropOptions { ApiToken = "bench-token" });
-        _tools = new RaindropsTools(_raindropsApiMock.Object, new RaindropCacheService(), options);
+        _tools = new RaindropsTools(
+            _raindropsApiMock.Object,
+            new RaindropCacheService(),
+            Mock.Of<ICollectionSuggestionService>(),
+            options);
 
         _preAllocatedList = new List<Raindrop>(ItemCount);
         for (int i = 0; i < ItemCount; i++)

--- a/tests/Mcp.Tests/Benchmarks/RaindropsChunkingBenchmark.cs
+++ b/tests/Mcp.Tests/Benchmarks/RaindropsChunkingBenchmark.cs
@@ -1,4 +1,5 @@
 using Mcp.Common;
+using Mcp.Collections.Suggestions;
 using Mcp.Raindrops;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -31,7 +32,11 @@ public class RaindropsChunkingBenchmark
             });
 
         var options = Options.Create(new RaindropOptions { ApiToken = "bench-token" });
-        var tool = new RaindropsTools(apiMock.Object, new RaindropCacheService(), options);
+        var tool = new RaindropsTools(
+            apiMock.Object,
+            new RaindropCacheService(),
+            Mock.Of<ICollectionSuggestionService>(),
+            options);
         var uniqueId = Guid.NewGuid().ToString("N");
         _output.WriteLine($"TestID: {uniqueId}");
 

--- a/tests/Mcp.Tests/CollectionSuggestionServiceTests.cs
+++ b/tests/Mcp.Tests/CollectionSuggestionServiceTests.cs
@@ -1,0 +1,125 @@
+using Mcp.Collections;
+using Mcp.Collections.Suggestions;
+using Mcp.Common;
+using Mcp.Raindrops;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Mcp.Tests;
+
+public class CollectionSuggestionServiceTests
+{
+    private readonly Mock<IRaindropsApi> _api = new();
+    private readonly CollectionSuggestionService _service;
+
+    public CollectionSuggestionServiceTests()
+    {
+        _service = new CollectionSuggestionService(
+            _api.Object,
+            new CollectionSuggestionIndexCache(),
+            Options.Create(new RaindropOptions { ApiToken = Guid.NewGuid().ToString() }));
+    }
+
+    [Fact]
+    public async Task SuggestAsync_RanksUsingLexicalTagAndDomainSignals()
+    {
+        var development = new Collection { Id = 1, Title = "Software Development", Description = "Programming resources" };
+        var cooking = new Collection { Id = 2, Title = "Cooking", Description = "Food and recipes" };
+        SetupLibrary(
+        [
+            new Raindrop
+            {
+                Id = 10, Link = "https://learn.microsoft.com/dotnet", Title = ".NET dependency injection",
+                Excerpt = "C# programming guide", Tags = ["dotnet", "code"], Domain = "learn.microsoft.com",
+                Collection = new IdRef { Id = development.Id }
+            },
+            new Raindrop
+            {
+                Id = 11, Link = "https://food.example/pasta", Title = "Pasta recipe",
+                Tags = ["recipe"], Domain = "food.example", Collection = new IdRef { Id = cooking.Id }
+            }
+        ]);
+        var query = new Raindrop
+        {
+            Link = "https://learn.microsoft.com/aspnet",
+            Title = "ASP.NET programming",
+            Excerpt = "A .NET development guide",
+            Tags = ["dotnet"],
+            Domain = "learn.microsoft.com"
+        };
+
+        var suggestions = await _service.SuggestAsync(query, [development, cooking], 3, CancellationToken.None);
+
+        Assert.Equal(development.Id, suggestions[0].Collection.Id);
+        Assert.DoesNotContain(suggestions, suggestion => suggestion.Collection.Id == cooking.Id);
+    }
+
+    [Fact]
+    public async Task SuggestAsync_UsesCollectionMetadataForColdStartCollection()
+    {
+        var research = new Collection { Id = 1, Title = "Machine Learning Research", Description = "Papers and experiments" };
+        var travel = new Collection { Id = 2, Title = "Travel", Description = "Trips and hotels" };
+        SetupLibrary([]);
+        var query = new Raindrop
+        {
+            Link = "https://arxiv.org/paper",
+            Title = "Machine learning research paper",
+            Excerpt = "New experimental results"
+        };
+
+        var suggestions = await _service.SuggestAsync(query, [research, travel], 3, CancellationToken.None);
+
+        Assert.Single(suggestions);
+        Assert.Equal(research.Id, suggestions[0].Collection.Id);
+    }
+
+    [Fact]
+    public async Task SuggestAsync_ReturnsStableCollectionIdOrderForTies()
+    {
+        var first = new Collection { Id = 1, Title = "Dotnet" };
+        var second = new Collection { Id = 2, Title = "Dotnet" };
+        SetupLibrary([]);
+        var query = new Raindrop { Link = "https://example.com", Title = "Dotnet" };
+
+        var suggestions = await _service.SuggestAsync(query, [second, first], 2, CancellationToken.None);
+
+        Assert.Equal([1, 2], suggestions.Select(suggestion => suggestion.Collection.Id));
+    }
+
+    [Fact]
+    public async Task Invalidate_RebuildsTheHistoricalIndex()
+    {
+        var collection = new Collection { Id = 1, Title = "Development" };
+        SetupLibrary([new Raindrop { Id = 1, Link = "https://example.com", Title = "Rust", Collection = new IdRef { Id = 1 } }]);
+        var query = new Raindrop { Link = "https://example.com", Title = "Rust" };
+        await _service.SuggestAsync(query, [collection], 1, CancellationToken.None);
+
+        _service.Invalidate();
+        await _service.SuggestAsync(query, [collection], 1, CancellationToken.None);
+
+        _api.Verify(api => api.ListAsync(0, null, null, 0, 50, true, It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task SuggestAsync_DoesNotCacheFailedIndexBuild()
+    {
+        var collection = new Collection { Id = 1, Title = "Development" };
+        _api.SetupSequence(api => api.ListAsync(0, null, null, 0, 50, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ItemsResponse<Raindrop>(false, []))
+            .ReturnsAsync(new ItemsResponse<Raindrop>(true, []));
+        var query = new Raindrop { Link = "https://example.com", Title = "Development" };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _service.SuggestAsync(query, [collection], 1, CancellationToken.None));
+        var suggestions = await _service.SuggestAsync(query, [collection], 1, CancellationToken.None);
+
+        Assert.Single(suggestions);
+        _api.Verify(api => api.ListAsync(0, null, null, 0, 50, true, It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    private void SetupLibrary(IReadOnlyList<Raindrop> bookmarks)
+    {
+        _api.Setup(api => api.ListAsync(0, null, null, 0, 50, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ItemsResponse<Raindrop>(true, bookmarks));
+    }
+}

--- a/tests/Mcp.Tests/CollectionsCachingTests.cs
+++ b/tests/Mcp.Tests/CollectionsCachingTests.cs
@@ -1,4 +1,5 @@
 using Mcp.Collections;
+using Mcp.Collections.Suggestions;
 using Mcp.Raindrops;
 using Mcp.Common;
 using ModelContextProtocol.Server;
@@ -19,6 +20,7 @@ public class CollectionsCachingTests : IDisposable
     private readonly Mock<ICollectionsApi> _collectionsApiMock;
     private readonly Mock<IRaindropsApi> _raindropsApiMock;
     private readonly Mock<McpServer> _mcpServerMock;
+    private readonly Mock<ICollectionSuggestionService> _suggestionServiceMock;
     private readonly RaindropCacheService _cacheService;
     private readonly CollectionsTools _tools;
 
@@ -27,10 +29,16 @@ public class CollectionsCachingTests : IDisposable
         _collectionsApiMock = new Mock<ICollectionsApi>();
         _raindropsApiMock = new Mock<IRaindropsApi>();
         _mcpServerMock = new Mock<McpServer>();
+        _suggestionServiceMock = new Mock<ICollectionSuggestionService>();
         _cacheService = new RaindropCacheService();
 
         var options = Options.Create(new RaindropOptions { ApiToken = "dummy-token" });
-        _tools = new CollectionsTools(_collectionsApiMock.Object, _raindropsApiMock.Object, _cacheService, options);
+        _tools = new CollectionsTools(
+            _collectionsApiMock.Object,
+            _raindropsApiMock.Object,
+            _cacheService,
+            _suggestionServiceMock.Object,
+            options);
 
         // Setup default responses
         _collectionsApiMock.Setup(x => x.ListAsync(It.IsAny<CancellationToken>()))
@@ -42,22 +50,17 @@ public class CollectionsCachingTests : IDisposable
         _raindropsApiMock.Setup(x => x.GetAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ItemResponse<Raindrop>(true, new Raindrop { Id = 123, Title = "Test", Link = "url" }));
 
+        _suggestionServiceMock.Setup(x => x.SuggestAsync(
+                It.IsAny<Raindrop>(),
+                It.IsAny<IReadOnlyCollection<Collection>>(),
+                3,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new CollectionSuggestion(new Collection { Id = 1, Title = "Tech" }, 1)]);
         _mcpServerMock.Setup(x => x.ClientCapabilities)
             .Returns(new ClientCapabilities
             {
-                Sampling = new SamplingCapability(),
                 Elicitation = new ElicitationCapability { Form = new FormElicitationCapability() }
             });
-
-        var llmResponse = new CreateMessageResult
-        {
-            Role = Role.Assistant,
-            Content = [new TextContentBlock { Text = "Tech" }],
-            Model = "test-model"
-        };
-
-        _mcpServerMock.Setup(x => x.SendRequestAsync(It.Is<JsonRpcRequest>(r => r.Method == "sampling/createMessage"), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new JsonRpcResponse { Result = JsonSerializer.SerializeToNode(llmResponse) });
 
         var elicitResult = new ElicitResult
         {

--- a/tests/Mcp.Tests/CollectionsToolsTests.cs
+++ b/tests/Mcp.Tests/CollectionsToolsTests.cs
@@ -1,34 +1,39 @@
-using Mcp.Collections;
-using Mcp.Raindrops;
-using Mcp.Common;
-using ModelContextProtocol.Server;
-using ModelContextProtocol.Protocol;
-using Moq;
-using Xunit;
 using System.Text.Json;
-using Xunit.Abstractions;
 using System.Text.Json.Nodes;
+using Mcp.Collections;
+using Mcp.Collections.Suggestions;
+using Mcp.Common;
+using Mcp.Raindrops;
 using Microsoft.Extensions.Options;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Moq;
 
 namespace Mcp.Tests;
 
 [Collection("Sequential")]
 public class CollectionsToolsTests
 {
-    private readonly Mock<ICollectionsApi> _collectionsApiMock;
-    private readonly Mock<IRaindropsApi> _raindropsApiMock;
-    private readonly Mock<McpServer> _mcpServerMock;
+    private readonly Mock<ICollectionsApi> _collectionsApiMock = new();
+    private readonly Mock<IRaindropsApi> _raindropsApiMock = new();
+    private readonly Mock<ICollectionSuggestionService> _suggestionServiceMock = new();
+    private readonly Mock<McpServer> _mcpServerMock = new();
     private readonly CollectionsTools _tools;
-    private readonly ITestOutputHelper _output;
 
-    public CollectionsToolsTests(ITestOutputHelper output)
+    public CollectionsToolsTests()
     {
-        _output = output;
-        _collectionsApiMock = new Mock<ICollectionsApi>();
-        _raindropsApiMock = new Mock<IRaindropsApi>();
-        _mcpServerMock = new Mock<McpServer>();
         var options = Options.Create(new RaindropOptions { ApiToken = "dummy-token" });
-        _tools = new CollectionsTools(_collectionsApiMock.Object, _raindropsApiMock.Object, new RaindropCacheService(), options);
+        _tools = new CollectionsTools(
+            _collectionsApiMock.Object,
+            _raindropsApiMock.Object,
+            new RaindropCacheService(),
+            _suggestionServiceMock.Object,
+            options);
+        _mcpServerMock.Setup(server => server.ClientCapabilities)
+            .Returns(new ClientCapabilities
+            {
+                Elicitation = new ElicitationCapability { Form = new FormElicitationCapability() }
+            });
     }
 
     [Theory]
@@ -44,274 +49,97 @@ public class CollectionsToolsTests
     [InlineData("Line\u2029Break", "Line Break")]
     [InlineData(null, "")]
     [InlineData("", "")]
-    public void Sanitize_HandlesVariousCharacters(string? input, string expected)
-    {
-        // Act
-        var result = CollectionsTools.Sanitize(input);
+    public void Sanitize_HandlesVariousCharacters(string? input, string expected) =>
+        Assert.Equal(expected, CollectionsTools.Sanitize(input));
 
-        // Assert
-        Assert.Equal(expected, result);
+    [Fact]
+    public async Task SuggestCollectionForBookmarkAsync_ReturnsFalse_WhenClassifierHasNoSuggestions()
+    {
+        var bookmark = ArrangeBookmarkAndCollections();
+        _suggestionServiceMock
+            .Setup(service => service.SuggestAsync(bookmark, It.IsAny<IReadOnlyCollection<Collection>>(), 3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var result = await _tools.SuggestCollectionForBookmarkAsync(_mcpServerMock.Object, bookmark.Id, CancellationToken.None);
+
+        Assert.False(result.Result);
+        _mcpServerMock.Verify(
+            server => server.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
-    public async Task SuggestCollectionForBookmarkAsync_ReturnsFalse_WhenParsingFails()
+    public async Task SuggestCollectionForBookmarkAsync_MovesBookmarkToAcceptedSuggestion()
     {
-        // Arrange
-        long bookmarkId = 123;
-        var bookmark = new Raindrop { Id = bookmarkId, Title = "Test", Link = "url", Excerpt = "excerpt" };
-
-        _raindropsApiMock.Setup(x => x.GetAsync(bookmarkId, It.IsAny<CancellationToken>()))
+        var bookmark = ArrangeBookmarkAndCollections();
+        var tech = new Collection { Id = 1, Title = "Science, Tech & Nature" };
+        _suggestionServiceMock
+            .Setup(service => service.SuggestAsync(bookmark, It.IsAny<IReadOnlyCollection<Collection>>(), 3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new CollectionSuggestion(tech, 0.9)]);
+        SetupElicitation("Science, Tech & Nature");
+        _raindropsApiMock
+            .Setup(api => api.UpdateAsync(bookmark.Id, It.IsAny<Raindrop>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ItemResponse<Raindrop>(true, bookmark));
 
-        _collectionsApiMock.Setup(x => x.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ItemsResponse<Collection>(true, new List<Collection>
-            {
-                new Collection { Id = 1, Title = "Tech" }
-            }));
+        var result = await _tools.SuggestCollectionForBookmarkAsync(_mcpServerMock.Object, bookmark.Id, CancellationToken.None);
 
-        var llmResponse = new CreateMessageResult
-        {
-            Role = Role.Assistant,
-            Content = [new TextContentBlock { Text = "This is a sentence, not a list." }],
-            Model = "test-model"
-        };
+        Assert.True(result.Result);
+        _raindropsApiMock.Verify(api => api.UpdateAsync(
+            bookmark.Id,
+            It.Is<Raindrop>(update => update.Collection != null && update.Collection.Id == tech.Id),
+            It.IsAny<CancellationToken>()));
+        _suggestionServiceMock.Verify(service => service.Invalidate(), Times.Once);
+    }
 
-        // Mock ClientCapabilities to support sampling
-        _mcpServerMock.Setup(x => x.ClientCapabilities)
-            .Returns(new ClientCapabilities
-            {
-                Sampling = new SamplingCapability(),
-                Elicitation = new ElicitationCapability { Form = new FormElicitationCapability() }
-            });
+    [Fact]
+    public async Task SuggestCollectionForBookmarkAsync_DoesNotMoveBookmarkWhenUserDeclines()
+    {
+        var bookmark = ArrangeBookmarkAndCollections();
+        var tech = new Collection { Id = 1, Title = "Tech" };
+        _suggestionServiceMock
+            .Setup(service => service.SuggestAsync(bookmark, It.IsAny<IReadOnlyCollection<Collection>>(), 3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new CollectionSuggestion(tech, 0.8)]);
+        SetupElicitation(null);
 
-        // Mock SendRequestAsync to return the LLM response
-        _mcpServerMock.Setup(x => x.SendRequestAsync(It.Is<JsonRpcRequest>(r => r.Method == "sampling/createMessage"), It.IsAny<CancellationToken>()))
+        var result = await _tools.SuggestCollectionForBookmarkAsync(_mcpServerMock.Object, bookmark.Id, CancellationToken.None);
+
+        Assert.False(result.Result);
+        _raindropsApiMock.Verify(
+            api => api.UpdateAsync(It.IsAny<long>(), It.IsAny<Raindrop>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private Raindrop ArrangeBookmarkAndCollections()
+    {
+        var bookmark = new Raindrop { Id = 123, Title = "Test", Link = "https://example.com" };
+        _raindropsApiMock.Setup(api => api.GetAsync(bookmark.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ItemResponse<Raindrop>(true, bookmark));
+        _collectionsApiMock.Setup(api => api.ListAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ItemsResponse<Collection>(true,
+            [
+                new Collection { Id = 1, Title = "Science, Tech & Nature" },
+                new Collection { Id = 2, Title = "News" }
+            ]));
+        return bookmark;
+    }
+
+    private void SetupElicitation(string? selectedCollection)
+    {
+        _mcpServerMock.Setup(server => server.SendRequestAsync(
+                It.Is<JsonRpcRequest>(request => request.Method == "elicitation/create"),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(new JsonRpcResponse
             {
-                Result = JsonSerializer.SerializeToNode(llmResponse)
-            });
-
-        // Act
-        var result = await _tools.SuggestCollectionForBookmarkAsync(_mcpServerMock.Object, bookmarkId, CancellationToken.None);
-
-        // Assert
-        Assert.False(result.Result);
-    }
-
-    [Fact]
-    public async Task SuggestCollectionForBookmarkAsync_HandlesBulletPoints()
-    {
-        // Arrange
-        long bookmarkId = 123;
-        var bookmark = new Raindrop { Id = bookmarkId, Title = "Test", Link = "url", Excerpt = "excerpt" };
-
-        _raindropsApiMock.Setup(x => x.GetAsync(bookmarkId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ItemResponse<Raindrop>(true, bookmark));
-
-        _collectionsApiMock.Setup(x => x.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ItemsResponse<Collection>(true, new List<Collection>
-            {
-                new Collection { Id = 1, Title = "Tech" },
-                new Collection { Id = 2, Title = "News" }
-            }));
-
-        var llmResponse = new CreateMessageResult
-        {
-            Role = Role.Assistant,
-            Content = [new TextContentBlock { Text = "- Tech\n- News" }],
-            Model = "test-model"
-        };
-
-        _mcpServerMock.Setup(x => x.ClientCapabilities)
-            .Returns(new ClientCapabilities
-            {
-                Sampling = new SamplingCapability(),
-                Elicitation = new ElicitationCapability { Form = new FormElicitationCapability() }
-            });
-
-        // Spy on SendRequestAsync
-        _mcpServerMock.Setup(x => x.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((JsonRpcRequest r, CancellationToken t) =>
-            {
-                _output.WriteLine($"Request Method: {r.Method}");
-
-                if (r.Method == "sampling/createMessage")
+                Result = JsonSerializer.SerializeToNode(new ElicitResult
                 {
-                    return new JsonRpcResponse
-                    {
-                        Result = JsonSerializer.SerializeToNode(llmResponse)
-                    };
-                }
-
-                if (r.Method == "elicitation/create") // or whatever the method was
-                {
-                    var elicitResult = new ElicitResult
-                    {
-                        Action = "accept",
-                        Content = new Dictionary<string, JsonElement>
+                    Action = selectedCollection is null ? "decline" : "accept",
+                    Content = selectedCollection is null
+                        ? null
+                        : new Dictionary<string, JsonElement>
                         {
-                            ["collectionName"] = JsonSerializer.SerializeToElement("Tech")
+                            ["collectionName"] = JsonSerializer.SerializeToElement(selectedCollection)
                         }
-                    };
-                    return new JsonRpcResponse
-                    {
-                        Result = JsonSerializer.SerializeToNode(elicitResult)
-                    };
-                }
-
-                // Return empty response for others to avoid NRE if possible, but clean inspection is goal.
-                return new JsonRpcResponse { Result = JsonNode.Parse("{}") };
+                })
             });
-
-        _raindropsApiMock.Setup(x => x.UpdateAsync(bookmarkId, It.IsAny<Raindrop>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ItemResponse<Raindrop>(true, bookmark));
-
-        // Act
-        var result = await _tools.SuggestCollectionForBookmarkAsync(_mcpServerMock.Object, bookmarkId, CancellationToken.None);
-
-        // Assert
-        Assert.True(result.Result);
-    }
-
-    [Fact]
-    public async Task SuggestCollectionForBookmarkAsync_HandlesPipeSeparatedList()
-    {
-        // Arrange
-        long bookmarkId = 123;
-        var bookmark = new Raindrop { Id = bookmarkId, Title = "Test", Link = "url", Excerpt = "excerpt" };
-
-        _raindropsApiMock.Setup(x => x.GetAsync(bookmarkId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ItemResponse<Raindrop>(true, bookmark));
-
-        _collectionsApiMock.Setup(x => x.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ItemsResponse<Collection>(true, new List<Collection>
-            {
-                new Collection { Id = 1, Title = "Tech" },
-                new Collection { Id = 2, Title = "News" }
-            }));
-
-        var llmResponse = new CreateMessageResult
-        {
-            Role = Role.Assistant,
-            Content = [new TextContentBlock { Text = "Tech | News" }],
-            Model = "test-model"
-        };
-
-        _mcpServerMock.Setup(x => x.ClientCapabilities)
-            .Returns(new ClientCapabilities
-            {
-                Sampling = new SamplingCapability(),
-                Elicitation = new ElicitationCapability { Form = new FormElicitationCapability() }
-            });
-
-        _mcpServerMock.Setup(x => x.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((JsonRpcRequest r, CancellationToken t) =>
-            {
-                if (r.Method == "sampling/createMessage")
-                {
-                    return new JsonRpcResponse
-                    {
-                        Result = JsonSerializer.SerializeToNode(llmResponse)
-                    };
-                }
-
-                if (r.Method == "elicitation/create")
-                {
-                    var elicitResult = new ElicitResult
-                    {
-                        Action = "accept",
-                        Content = new Dictionary<string, JsonElement>
-                        {
-                            ["collectionName"] = JsonSerializer.SerializeToElement("Tech")
-                        }
-                    };
-                    return new JsonRpcResponse
-                    {
-                        Result = JsonSerializer.SerializeToNode(elicitResult)
-                    };
-                }
-
-                return new JsonRpcResponse { Result = JsonNode.Parse("{}") };
-            });
-
-        _raindropsApiMock.Setup(x => x.UpdateAsync(bookmarkId, It.IsAny<Raindrop>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ItemResponse<Raindrop>(true, bookmark));
-
-        // Act
-        var result = await _tools.SuggestCollectionForBookmarkAsync(_mcpServerMock.Object, bookmarkId, CancellationToken.None);
-
-        // Assert
-        Assert.True(result.Result);
-    }
-
-    [Fact]
-    public async Task SuggestCollectionForBookmarkAsync_HandlesCollectionWithComma()
-    {
-        // Arrange
-        long bookmarkId = 123;
-        var bookmark = new Raindrop { Id = bookmarkId, Title = "Test", Link = "url", Excerpt = "excerpt" };
-
-        _raindropsApiMock.Setup(x => x.GetAsync(bookmarkId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ItemResponse<Raindrop>(true, bookmark));
-
-        _collectionsApiMock.Setup(x => x.ListAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ItemsResponse<Collection>(true, new List<Collection>
-            {
-                new Collection { Id = 1, Title = "Science, Tech & Nature" },
-                new Collection { Id = 2, Title = "Other" }
-            }));
-
-        var llmResponse = new CreateMessageResult
-        {
-            Role = Role.Assistant,
-            Content = [new TextContentBlock { Text = "Science, Tech & Nature | Other" }],
-            Model = "test-model"
-        };
-
-        _mcpServerMock.Setup(x => x.ClientCapabilities)
-            .Returns(new ClientCapabilities
-            {
-                Sampling = new SamplingCapability(),
-                Elicitation = new ElicitationCapability { Form = new FormElicitationCapability() }
-            });
-
-        _mcpServerMock.Setup(x => x.SendRequestAsync(It.IsAny<JsonRpcRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((JsonRpcRequest r, CancellationToken t) =>
-            {
-                if (r.Method == "sampling/createMessage")
-                {
-                    return new JsonRpcResponse
-                    {
-                        Result = JsonSerializer.SerializeToNode(llmResponse)
-                    };
-                }
-
-                if (r.Method == "elicitation/create")
-                {
-                    var elicitResult = new ElicitResult
-                    {
-                        Action = "accept",
-                        Content = new Dictionary<string, JsonElement>
-                        {
-                            ["collectionName"] = JsonSerializer.SerializeToElement("Science, Tech & Nature")
-                        }
-                    };
-                    return new JsonRpcResponse
-                    {
-                        Result = JsonSerializer.SerializeToNode(elicitResult)
-                    };
-                }
-
-                return new JsonRpcResponse { Result = JsonNode.Parse("{}") };
-            });
-
-        _raindropsApiMock.Setup(x => x.UpdateAsync(bookmarkId, It.IsAny<Raindrop>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ItemResponse<Raindrop>(true, bookmark));
-
-        // Act
-        var result = await _tools.SuggestCollectionForBookmarkAsync(_mcpServerMock.Object, bookmarkId, CancellationToken.None);
-
-        // Assert
-        Assert.True(result.Result);
     }
 }

--- a/tests/Mcp.Tests/RaindropsChunkingTests.cs
+++ b/tests/Mcp.Tests/RaindropsChunkingTests.cs
@@ -1,4 +1,5 @@
 using Mcp.Common;
+using Mcp.Collections.Suggestions;
 using Mcp.Raindrops;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -10,14 +11,16 @@ public class RaindropsChunkingTests
 {
     private readonly Mock<IRaindropsApi> _apiMock;
     private readonly Mock<IRaindropCacheService> _cacheMock;
+    private readonly Mock<ICollectionSuggestionService> _suggestionServiceMock;
     private readonly RaindropsTools _tools;
 
     public RaindropsChunkingTests()
     {
         _apiMock = new Mock<IRaindropsApi>();
         _cacheMock = new Mock<IRaindropCacheService>();
+        _suggestionServiceMock = new Mock<ICollectionSuggestionService>();
         var options = Options.Create(new RaindropOptions { ApiToken = "test-token" });
-        _tools = new RaindropsTools(_apiMock.Object, _cacheMock.Object, options);
+        _tools = new RaindropsTools(_apiMock.Object, _cacheMock.Object, _suggestionServiceMock.Object, options);
     }
 
     [Fact]
@@ -129,6 +132,7 @@ public class RaindropsChunkingTests
         Assert.Equal(100, result.Items.Count);
         // Cache SHOULD be invalidated if we successfully created ANY items (100 items here)
         _cacheMock.Verify(x => x.InvalidateAllAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        _suggestionServiceMock.Verify(x => x.Invalidate(), Times.Once);
     }
 
     [Fact]
@@ -147,6 +151,7 @@ public class RaindropsChunkingTests
         Assert.True(result.Result);
         Assert.Equal(150, result.Items.Count);
         _cacheMock.Verify(x => x.InvalidateAllAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        _suggestionServiceMock.Verify(x => x.Invalidate(), Times.Once);
     }
 
     private IEnumerable<Raindrop> CreateRaindrops(int count)

--- a/tests/Mcp.Tests/RaindropsSuggestionInvalidationTests.cs
+++ b/tests/Mcp.Tests/RaindropsSuggestionInvalidationTests.cs
@@ -1,0 +1,84 @@
+using Mcp.Collections.Suggestions;
+using Mcp.Common;
+using Mcp.Raindrops;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Mcp.Tests;
+
+public class RaindropsSuggestionInvalidationTests
+{
+    private readonly Mock<IRaindropsApi> _apiMock = new();
+    private readonly Mock<ICollectionSuggestionService> _suggestionServiceMock = new();
+    private readonly RaindropsTools _tools;
+
+    public RaindropsSuggestionInvalidationTests()
+    {
+        _tools = new RaindropsTools(
+            _apiMock.Object,
+            Mock.Of<IRaindropCacheService>(),
+            _suggestionServiceMock.Object,
+            Options.Create(new RaindropOptions { ApiToken = "test-token" }));
+    }
+
+    [Fact]
+    public async Task CreateBookmarkAsync_WhenSuccessful_InvalidatesSuggestionIndex()
+    {
+        _apiMock.Setup(x => x.CreateAsync(It.IsAny<Raindrop>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ItemResponse<Raindrop>(true, new Raindrop()));
+
+        await _tools.CreateBookmarkAsync(new RaindropCreateRequest(), CancellationToken.None);
+
+        _suggestionServiceMock.Verify(x => x.Invalidate(), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateBookmarkAsync_WhenSuccessful_InvalidatesSuggestionIndex()
+    {
+        _apiMock.Setup(x => x.UpdateAsync(It.IsAny<long>(), It.IsAny<Raindrop>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ItemResponse<Raindrop>(true, new Raindrop()));
+
+        await _tools.UpdateBookmarkAsync(1, new RaindropUpdateRequest(), CancellationToken.None);
+
+        _suggestionServiceMock.Verify(x => x.Invalidate(), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteBookmarkAsync_WhenSuccessful_InvalidatesSuggestionIndex()
+    {
+        _apiMock.Setup(x => x.DeleteAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SuccessResponse(true));
+
+        await _tools.DeleteBookmarkAsync(1, CancellationToken.None);
+
+        _suggestionServiceMock.Verify(x => x.Invalidate(), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateBookmarksAsync_WhenSuccessful_InvalidatesSuggestionIndex()
+    {
+        _apiMock.Setup(x => x.UpdateManyAsync(
+                It.IsAny<int>(),
+                It.IsAny<RaindropBulkUpdate>(),
+                It.IsAny<bool?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SuccessResponse(true));
+
+        await _tools.UpdateBookmarksAsync(1, new RaindropBulkUpdate(), cancellationToken: CancellationToken.None);
+
+        _suggestionServiceMock.Verify(x => x.Invalidate(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Mutation_WhenUnsuccessful_DoesNotInvalidateSuggestionIndex()
+    {
+        _apiMock.Setup(x => x.DeleteAsync(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SuccessResponse(false));
+
+        await _tools.DeleteBookmarkAsync(1, CancellationToken.None);
+
+        _suggestionServiceMock.Verify(x => x.Invalidate(), Times.Never);
+    }
+}

--- a/tests/Mcp.Tests/RaindropsToolsPerformanceTests.cs
+++ b/tests/Mcp.Tests/RaindropsToolsPerformanceTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Mcp.Common;
+using Mcp.Collections.Suggestions;
 using Mcp.Raindrops;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -21,7 +22,7 @@ public class RaindropsToolsPerformanceTests : IDisposable
         _apiMock = new Mock<IRaindropsApi>();
         _cacheService = new RaindropCacheService();
         var options = Options.Create(new RaindropOptions { ApiToken = "test-token-for-performance-testing-longer-string-to-make-hashing-sligtly-more-expensive" });
-        _tools = new RaindropsTools(_apiMock.Object, _cacheService, options);
+        _tools = new RaindropsTools(_apiMock.Object, _cacheService, Mock.Of<ICollectionSuggestionService>(), options);
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation

- Replace MCP sampling-based ranking (deprecated and non-deterministic) with a server-owned deterministic classifier to make suggestions reproducible and explainable.
- Keep the user confirmation step (MCP elicitation) while avoiding generative inference for ranking.
- Provide a simple, explainable baseline (lexical, tag, domain signals) with a clear roadmap for optional embeddings and advanced retrieval.

### Description

- Introduce a new suggestion subsystem with `ICollectionSuggestionService`, a concrete `CollectionSuggestionService`, and an in-memory `CollectionSuggestionIndexCache` that builds a per-API-token index from historical bookmarks; scoring blends TF-IDF cosine, tag Jaccard, and domain affinity with configurable weights.
- Replace sampling-based ranking in `CollectionsTools.SuggestCollectionForBookmarkAsync` with deterministic calls to `ICollectionSuggestionService.SuggestAsync`, preserving MCP elicitation for user choice and sanitizing collection titles; call `ICollectionSuggestionService.Invalidate()` after collection mutations and successful bookmark moves.
- Add DI registrations: `CollectionSuggestionIndexCache` as singleton and `ICollectionSuggestionService` as transient in `RaindropServiceCollectionExtensions`.
- Add documentation `docs/DETERMINISTIC_COLLECTION_SUGGESTIONS.md` describing the migration, phases (lexical baseline, optional embeddings, advanced retrieval), evaluation plan, and operational/privacy notes.
- Update benchmarks and tests to inject or mock `ICollectionSuggestionService` and add `CollectionSuggestionServiceTests` covering ranking signals, cold-start behavior, tie stability, index invalidation, and failed-build handling.

### Testing

- Ran unit tests in `Mcp.Tests`, including `CollectionSuggestionServiceTests`, `CollectionsToolsTests`, and `CollectionsCachingTests`, which exercise the new service, DI wiring, and suggestion/elicitation flow; these tests completed successfully.
- Updated benchmark project `Mcp.Benchmarks` to exercise `SuggestCollectionForBookmarkAsync` and `MergeCollectionsAsync` with the suggestion service mocked; benchmarks build and run in CI as part of performance checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8655df056c833093c0f27108f21ec0)