### PR TITLE
feat: implement phase 2 deterministic collection suggestions

### DIFF
--- a/docs/DETERMINISTIC_COLLECTION_SUGGESTIONS.md
+++ b/docs/DETERMINISTIC_COLLECTION_SUGGESTIONS.md
@@ -33,7 +33,7 @@ Ranking is exact rather than approximate. Results are ordered by descending scor
 - External bookmark moves do not immediately invalidate the index; a restart or a successful mutation through this server rebuilds it.
 - Only top-level collections are candidates, preserving the previous tool behavior.
 
-### Phase 2: optional vector embeddings
+### Phase 2: optional vector embeddings — implemented
 
 Add an optional `IEmbeddingGenerator<string, Embedding<float>>` implementation through `Microsoft.Extensions.AI`.
 

--- a/src/Mcp/Collections/Suggestions/CollectionSuggestionIndexCache.cs
+++ b/src/Mcp/Collections/Suggestions/CollectionSuggestionIndexCache.cs
@@ -45,4 +45,5 @@ internal sealed record CollectionSuggestionIndex(
 internal sealed record CollectionFeatures(
     IReadOnlyDictionary<string, int> Terms,
     IReadOnlyDictionary<string, int> Tags,
-    IReadOnlyDictionary<string, int> Domains);
+    IReadOnlyDictionary<string, int> Domains,
+    Microsoft.Extensions.AI.Embedding<float>? Centroid = null);

--- a/src/Mcp/Collections/Suggestions/CollectionSuggestionIndexCache.cs
+++ b/src/Mcp/Collections/Suggestions/CollectionSuggestionIndexCache.cs
@@ -46,4 +46,6 @@ internal sealed record CollectionFeatures(
     IReadOnlyDictionary<string, int> Terms,
     IReadOnlyDictionary<string, int> Tags,
     IReadOnlyDictionary<string, int> Domains,
-    Microsoft.Extensions.AI.Embedding<float>? Centroid = null);
+    Microsoft.Extensions.AI.Embedding<float>? Centroid = null,
+    float[]? EmbeddingSum = null,
+    int EmbeddingCount = 0);

--- a/src/Mcp/Collections/Suggestions/CollectionSuggestionService.cs
+++ b/src/Mcp/Collections/Suggestions/CollectionSuggestionService.cs
@@ -49,6 +49,10 @@ internal sealed partial class CollectionSuggestionService(
                 var embeddings = await embeddingGenerator.GenerateAsync([canonicalString], null, cancellationToken);
                 queryEmbedding = embeddings.FirstOrDefault();
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch
             {
                 // Fallback to Phase 1 lexical logic if embedding generation fails

--- a/src/Mcp/Collections/Suggestions/CollectionSuggestionService.cs
+++ b/src/Mcp/Collections/Suggestions/CollectionSuggestionService.cs
@@ -7,7 +7,8 @@ namespace Mcp.Collections.Suggestions;
 internal sealed partial class CollectionSuggestionService(
     IRaindropsApi raindropsApi,
     CollectionSuggestionIndexCache cache,
-    IOptions<RaindropOptions> options) : ICollectionSuggestionService
+    IOptions<RaindropOptions> options,
+    Microsoft.Extensions.AI.IEmbeddingGenerator<string, Microsoft.Extensions.AI.Embedding<float>>? embeddingGenerator = null) : ICollectionSuggestionService
 {
     private const int PageSize = 50;
     private const double LexicalWeight = 0.60;
@@ -35,19 +36,36 @@ internal sealed partial class CollectionSuggestionService(
         if (candidates.Count == 0)
             return [];
 
-        var index = await cache.GetOrCreateAsync(
-            _cacheKey,
-            () => BuildIndexAsync(candidates, cancellationToken));
         var queryTerms = TokenizeBookmark(bookmark);
         var queryTags = NormalizeTags(bookmark.Tags);
         var queryDomain = Normalize(bookmark.Domain);
+        var canonicalString = CreateCanonicalString(bookmark);
+
+        Microsoft.Extensions.AI.Embedding<float>? queryEmbedding = null;
+        if (embeddingGenerator != null && !string.IsNullOrWhiteSpace(canonicalString))
+        {
+            try
+            {
+                var embeddings = await embeddingGenerator.GenerateAsync([canonicalString], null, cancellationToken);
+                queryEmbedding = embeddings.FirstOrDefault();
+            }
+            catch
+            {
+                // Fallback to Phase 1 lexical logic if embedding generation fails
+                queryEmbedding = null;
+            }
+        }
+
+        var index = await cache.GetOrCreateAsync(
+            _cacheKey,
+            () => BuildIndexAsync(candidates, cancellationToken));
 
         index.Bookmarks.TryGetValue(bookmark.Id, out var indexedBookmark);
 
         return candidates.Values
             .Select(collection => new CollectionSuggestion(
                 collection,
-                Score(collection.Id, queryTerms, queryTags, queryDomain, index, indexedBookmark)))
+                Score(collection.Id, queryTerms, queryTags, queryDomain, queryEmbedding, index, indexedBookmark)))
             .Where(suggestion => suggestion.Score > 0)
             .OrderByDescending(suggestion => suggestion.Score)
             .ThenBy(suggestion => suggestion.Collection.Id)
@@ -87,6 +105,7 @@ internal sealed partial class CollectionSuggestionService(
                     continue;
 
                 var bookmarkTerms = TokenizeBookmark(bookmark);
+                var canonicalString = CreateCanonicalString(bookmark);
                 var bookmarkTags = NormalizeTags(bookmark.Tags);
                 var bookmarkDomain = Normalize(bookmark.Domain);
 
@@ -109,7 +128,8 @@ internal sealed partial class CollectionSuggestionService(
                         collectionId,
                         bookmarkTerms,
                         bookmarkTags,
-                        bookmarkDomain);
+                        bookmarkDomain,
+                        canonicalString);
                 }
             }
 
@@ -122,9 +142,53 @@ internal sealed partial class CollectionSuggestionService(
             foreach (var term in documentTerms.Keys)
                 Increment(documentFrequencies, term);
 
+
         var features = candidates.Keys.ToDictionary(
             id => id,
             id => new CollectionFeatures(terms[id], tags[id], domains[id]));
+
+        if (embeddingGenerator != null)
+        {
+            var bookmarksList = indexedBookmarks.Values.ToList();
+            var canonicalStrings = bookmarksList.Select(b => b.CanonicalString).ToList();
+            if (canonicalStrings.Count > 0)
+            {
+                try
+                {
+                    var embeddings = await embeddingGenerator.GenerateAsync(canonicalStrings, null, cancellationToken);
+                    var vectors = embeddings.Select(e => e.Vector.ToArray()).ToList();
+
+                    if (vectors.Count == bookmarksList.Count)
+                    {
+                        var collectionVectors = new Dictionary<int, List<float[]>>();
+                        for (int i = 0; i < bookmarksList.Count; i++)
+                        {
+                            var b = bookmarksList[i];
+                            if (!collectionVectors.TryGetValue(b.CollectionId, out var list))
+                            {
+                                list = new List<float[]>();
+                                collectionVectors[b.CollectionId] = list;
+                            }
+                            list.Add(vectors[i]);
+                        }
+
+                        foreach (var kvp in collectionVectors)
+                        {
+                            if (features.TryGetValue(kvp.Key, out var oldFeatures))
+                            {
+                                var centroid = CalculateCentroid(kvp.Value);
+                                features[kvp.Key] = oldFeatures with { Centroid = new Microsoft.Extensions.AI.Embedding<float>(centroid) };
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    // Fallback to Phase 1: skip generating centroids if embedding generation fails
+                }
+            }
+        }
+
         return new CollectionSuggestionIndex(features, documentFrequencies, candidates.Count, domainTotals, indexedBookmarks);
     }
 
@@ -133,6 +197,7 @@ internal sealed partial class CollectionSuggestionService(
         IReadOnlyDictionary<string, int> queryTerms,
         IReadOnlySet<string> queryTags,
         string? queryDomain,
+        Microsoft.Extensions.AI.Embedding<float>? queryEmbedding,
         CollectionSuggestionIndex index,
         IndexedBookmark? indexedBookmark)
     {
@@ -158,7 +223,45 @@ internal sealed partial class CollectionSuggestionService(
             }
         }
 
-        return LexicalWeight * lexical + TagWeight * tag + DomainWeight * domain;
+
+        double semantic = 0;
+        double finalScore = 0;
+
+        if (queryEmbedding != null && features.Centroid != null)
+        {
+            semantic = CosineSimilarity(queryEmbedding.Vector.ToArray(), features.Centroid.Vector.ToArray());
+            // Blend Phase 2 Semantic with Phase 1 scores
+            finalScore = 0.5 * semantic + 0.3 * lexical + 0.1 * tag + 0.1 * domain;
+        }
+        else
+        {
+            // Fallback to pure Phase 1
+            finalScore = LexicalWeight * lexical + TagWeight * tag + DomainWeight * domain;
+        }
+
+        return finalScore;
+    }
+
+
+    private static double CosineSimilarity(float[] left, float[] right)
+    {
+        if (left.Length == 0 || right.Length == 0 || left.Length != right.Length)
+            return 0;
+
+        double dot = 0;
+        double leftMag = 0;
+        double rightMag = 0;
+
+        for (int i = 0; i < left.Length; i++)
+        {
+            dot += left[i] * right[i];
+            leftMag += left[i] * left[i];
+            rightMag += right[i] * right[i];
+        }
+
+        if (leftMag == 0 || rightMag == 0) return 0;
+
+        return dot / (Math.Sqrt(leftMag) * Math.Sqrt(rightMag));
     }
 
     private static double TfIdfCosine(
@@ -280,6 +383,17 @@ internal sealed partial class CollectionSuggestionService(
         return union <= 0 ? 0 : (double)intersection / union;
     }
 
+        private static string CreateCanonicalString(Raindrop bookmark)
+    {
+        var parts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(bookmark.Title)) parts.Add(bookmark.Title);
+        if (!string.IsNullOrWhiteSpace(bookmark.Excerpt)) parts.Add(bookmark.Excerpt);
+        if (!string.IsNullOrWhiteSpace(bookmark.Note)) parts.Add(bookmark.Note);
+        if (bookmark.Tags?.Any() == true) parts.Add($"Tags: {string.Join(", ", bookmark.Tags)}");
+        if (!string.IsNullOrWhiteSpace(bookmark.Domain)) parts.Add($"Domain: {bookmark.Domain}");
+        return string.Join("\n", parts);
+    }
+
     private static Dictionary<string, int> TokenizeBookmark(Raindrop bookmark) =>
         CountTerms(Tokenize(bookmark.Title, bookmark.Link, bookmark.Excerpt, bookmark.Note, bookmark.Type, bookmark.Domain)
             .Concat(NormalizeTags(bookmark.Tags)));
@@ -294,6 +408,38 @@ internal sealed partial class CollectionSuggestionService(
 
     private static string? Normalize(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim().ToLowerInvariant();
+
+
+    private static float[] CalculateCentroid(List<float[]> vectors)
+    {
+        if (vectors.Count == 0) return Array.Empty<float>();
+
+        int dim = vectors[0].Length;
+        var centroid = new float[dim];
+
+        foreach (var v in vectors)
+        {
+            for (int i = 0; i < dim; i++)
+            {
+                centroid[i] += v[i];
+            }
+        }
+
+        for (int i = 0; i < dim; i++)
+        {
+            centroid[i] /= vectors.Count;
+        }
+
+        double mag = 0;
+        for (int i = 0; i < dim; i++) mag += centroid[i] * centroid[i];
+        if (mag > 0)
+        {
+            mag = Math.Sqrt(mag);
+            for (int i = 0; i < dim; i++) centroid[i] = (float)(centroid[i] / mag);
+        }
+
+        return centroid;
+    }
 
     private static Dictionary<string, int> CountTerms(IEnumerable<string> values)
     {

--- a/src/Mcp/Collections/Suggestions/CollectionSuggestionService.cs
+++ b/src/Mcp/Collections/Suggestions/CollectionSuggestionService.cs
@@ -164,6 +164,7 @@ internal sealed partial class CollectionSuggestionService(
                         for (int i = 0; i < bookmarksList.Count; i++)
                         {
                             var b = bookmarksList[i];
+                            indexedBookmarks[b.Id] = b with { Embedding = vectors[i] };
                             if (!collectionVectors.TryGetValue(b.CollectionId, out var list))
                             {
                                 list = new List<float[]>();
@@ -176,8 +177,14 @@ internal sealed partial class CollectionSuggestionService(
                         {
                             if (features.TryGetValue(kvp.Key, out var oldFeatures))
                             {
+                                var embeddingSum = CalculateSum(kvp.Value);
                                 var centroid = CalculateCentroid(kvp.Value);
-                                features[kvp.Key] = oldFeatures with { Centroid = new Microsoft.Extensions.AI.Embedding<float>(centroid) };
+                                features[kvp.Key] = oldFeatures with
+                                {
+                                    Centroid = new Microsoft.Extensions.AI.Embedding<float>(centroid),
+                                    EmbeddingSum = embeddingSum,
+                                    EmbeddingCount = kvp.Value.Count
+                                };
                             }
                         }
                     }
@@ -229,7 +236,10 @@ internal sealed partial class CollectionSuggestionService(
 
         if (queryEmbedding != null && features.Centroid != null)
         {
-            semantic = CosineSimilarity(queryEmbedding.Vector.ToArray(), features.Centroid.Vector.ToArray());
+            var centroid = isTargetCollection && indexedBookmark?.Embedding != null
+                ? CalculateLeaveOneOutCentroid(features, indexedBookmark.Embedding)
+                : features.Centroid.Vector.ToArray();
+            semantic = CosineSimilarity(queryEmbedding.Vector.ToArray(), centroid);
             // Blend Phase 2 Semantic with Phase 1 scores
             finalScore = 0.5 * semantic + 0.3 * lexical + 0.1 * tag + 0.1 * domain;
         }
@@ -262,6 +272,24 @@ internal sealed partial class CollectionSuggestionService(
         if (leftMag == 0 || rightMag == 0) return 0;
 
         return dot / (Math.Sqrt(leftMag) * Math.Sqrt(rightMag));
+    }
+
+    private static float[] CalculateLeaveOneOutCentroid(CollectionFeatures features, float[] excludedEmbedding)
+    {
+        if (features.EmbeddingSum is null || features.EmbeddingCount <= 1 ||
+            features.EmbeddingSum.Length != excludedEmbedding.Length)
+        {
+            return [];
+        }
+
+        var centroid = new float[features.EmbeddingSum.Length];
+        for (var i = 0; i < centroid.Length; i++)
+        {
+            centroid[i] = (features.EmbeddingSum[i] - excludedEmbedding[i]) / (features.EmbeddingCount - 1);
+        }
+
+        NormalizeVector(centroid);
+        return centroid;
     }
 
     private static double TfIdfCosine(
@@ -414,31 +442,40 @@ internal sealed partial class CollectionSuggestionService(
     {
         if (vectors.Count == 0) return Array.Empty<float>();
 
-        int dim = vectors[0].Length;
-        var centroid = new float[dim];
+        var centroid = CalculateSum(vectors);
 
-        foreach (var v in vectors)
-        {
-            for (int i = 0; i < dim; i++)
-            {
-                centroid[i] += v[i];
-            }
-        }
-
-        for (int i = 0; i < dim; i++)
+        for (int i = 0; i < centroid.Length; i++)
         {
             centroid[i] /= vectors.Count;
         }
 
+        NormalizeVector(centroid);
+        return centroid;
+    }
+
+    private static float[] CalculateSum(List<float[]> vectors)
+    {
+        var sum = new float[vectors[0].Length];
+        foreach (var vector in vectors)
+        {
+            for (var i = 0; i < sum.Length; i++)
+            {
+                sum[i] += vector[i];
+            }
+        }
+
+        return sum;
+    }
+
+    private static void NormalizeVector(float[] vector)
+    {
         double mag = 0;
-        for (int i = 0; i < dim; i++) mag += centroid[i] * centroid[i];
+        for (int i = 0; i < vector.Length; i++) mag += vector[i] * vector[i];
         if (mag > 0)
         {
             mag = Math.Sqrt(mag);
-            for (int i = 0; i < dim; i++) centroid[i] = (float)(centroid[i] / mag);
+            for (int i = 0; i < vector.Length; i++) vector[i] = (float)(vector[i] / mag);
         }
-
-        return centroid;
     }
 
     private static Dictionary<string, int> CountTerms(IEnumerable<string> values)

--- a/src/Mcp/Collections/Suggestions/IndexedBookmark.cs
+++ b/src/Mcp/Collections/Suggestions/IndexedBookmark.cs
@@ -5,4 +5,5 @@ internal sealed record IndexedBookmark(
     int CollectionId,
     IReadOnlyDictionary<string, int> Terms,
     IReadOnlySet<string> Tags,
-    string? Domain);
+    string? Domain,
+    string CanonicalString = "");

--- a/src/Mcp/Collections/Suggestions/IndexedBookmark.cs
+++ b/src/Mcp/Collections/Suggestions/IndexedBookmark.cs
@@ -6,4 +6,5 @@ internal sealed record IndexedBookmark(
     IReadOnlyDictionary<string, int> Terms,
     IReadOnlySet<string> Tags,
     string? Domain,
-    string CanonicalString = "");
+    string CanonicalString = "",
+    float[]? Embedding = null);

--- a/src/Mcp/Common/DummyEmbeddingGenerator.cs
+++ b/src/Mcp/Common/DummyEmbeddingGenerator.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.AI;
+
+namespace Mcp.Common;
+
+internal sealed class DummyEmbeddingGenerator : IEmbeddingGenerator<string, Embedding<float>>
+{
+    public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(new GeneratedEmbeddings<Embedding<float>>());
+    }
+
+    public void Dispose() { }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+}

--- a/src/Mcp/RaindropMcp.csproj
+++ b/src/Mcp/RaindropMcp.csproj
@@ -46,10 +46,7 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <Target Name="BuildMcpApp"
-          BeforeTargets="PrepareResourceNames"
-          Inputs="Ui\Static\index.html;Ui\Static\main.js;Ui\Static\package.json;Ui\Static\package-lock.json;Ui\Static\vite.config.js"
-          Outputs="Ui\Static\dist\index.html">
+  <Target Name="BuildMcpApp" BeforeTargets="PrepareResourceNames" Inputs="Ui\Static\index.html;Ui\Static\main.js;Ui\Static\package.json;Ui\Static\package-lock.json;Ui\Static\vite.config.js" Outputs="Ui\Static\dist\index.html">
     <Exec WorkingDirectory="Ui\Static" Command="npm ci" />
     <Exec WorkingDirectory="Ui\Static" Command="npm run build" />
   </Target>
@@ -67,6 +64,7 @@
   </Target>
 
   <ItemGroup>
+    <PackageReference Include="LocalEmbeddings" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.11" />

--- a/src/Mcp/RaindropOptions.cs
+++ b/src/Mcp/RaindropOptions.cs
@@ -20,4 +20,9 @@ public class RaindropOptions
     [Url]
     [RegularExpression(@"^(?i)https://.*", ErrorMessage = "BaseUrl must use HTTPS to prevent exposing the API token.")]
     public string BaseUrl { get; set; } = "https://api.raindrop.io/rest/v1";
+
+    /// <summary>
+    /// Whether to enable semantic collection suggestions using local embeddings (Phase 2).
+    /// </summary>
+    public bool EnableSemanticSuggestions { get; set; } = true;
 }

--- a/src/Mcp/RaindropServiceCollectionExtensions.cs
+++ b/src/Mcp/RaindropServiceCollectionExtensions.cs
@@ -14,6 +14,10 @@ using Mcp.User;
 using Mcp.Analytics;
 using Polly;
 using Polly.Extensions.Http;
+using LocalEmbeddings;
+using LocalEmbeddings.Options;
+using Microsoft.Extensions.AI;
+
 
 namespace Mcp;
 
@@ -46,6 +50,39 @@ public static class RaindropServiceCollectionExtensions
         services.AddSingleton<CollectionSuggestionIndexCache>();
         services.AddTransient<ICollectionSuggestionService, CollectionSuggestionService>();
         services.AddTransient<ILibraryAnalyticsService, LibraryAnalyticsService>();
+
+        if (configuration.GetSection("Raindrop").GetValue<bool>("EnableSemanticSuggestions", true))
+        {
+            // Note: because DI resolving fails if an interface isn't registered but is requested without nullability
+            // in some frameworks, we could use try-catch and NOT register it. However, the Microsoft DI container doesn't
+            // allow a factory to return null for AddSingleton<T> (where T is a reference type).
+            // The cleanest way is to just conditionally not register it! But what if a test needs it or it's requested?
+            // CollectionSuggestionService takes it as `IEmbeddingGenerator?`.
+            // So if we don't register it, DI injects null. Perfect!
+
+            // BUT! The LocalEmbeddingGenerator requires downloading models dynamically which might fail during the factory lambda
+            // if we put a try/catch inside it. Let's register it via a factory that returns null if instantiation fails?
+            // Microsoft DI throws if a factory returns null for a required service.
+            // Let's stick with the try-catch returning Dummy if it fails, and just ensure Dummy is safe.
+
+            services.AddSingleton<IEmbeddingGenerator<string, Embedding<float>>>(sp =>
+            {
+                var options = sp.GetRequiredService<IOptions<RaindropOptions>>().Value;
+                if (!options.EnableSemanticSuggestions) return new DummyEmbeddingGenerator();
+
+                try
+                {
+                    return new LocalEmbeddingGenerator(new LocalEmbeddingsOptions());
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Failed to load LocalEmbeddingGenerator, falling back to dummy: {ex.Message}");
+                    return new DummyEmbeddingGenerator();
+                }
+            });
+        }
+
+
 
         var settings = new RefitSettings
         {

--- a/src/Mcp/server.json
+++ b/src/Mcp/server.json
@@ -34,6 +34,12 @@
           "description": "The base URL for the Raindrop.io API.",
           "isRequired": false,
           "defaultValue": "https://api.raindrop.io/rest/v1"
+        },
+        {
+          "name": "Raindrop:EnableSemanticSuggestions",
+          "description": "Whether to enable local semantic embeddings for collection suggestions.",
+          "isRequired": false,
+          "defaultValue": "true"
         }
       ]
     }

--- a/tests/Mcp.Tests/CollectionSuggestionServiceTests.cs
+++ b/tests/Mcp.Tests/CollectionSuggestionServiceTests.cs
@@ -281,4 +281,52 @@ public class CollectionSuggestionServiceTests
         Assert.Equal(development.Id, suggestions[0].Collection.Id);
         mockEmbeddings.Verify(g => g.GenerateAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<Microsoft.Extensions.AI.EmbeddingGenerationOptions>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
+
+    [Fact]
+    public async Task SuggestAsync_ExcludesQueriedBookmarkFromOwnSemanticCentroid()
+    {
+        var current = new Collection { Id = 1, Title = "Current" };
+        var matching = new Collection { Id = 2, Title = "Matching" };
+        var queriedBookmark = new Raindrop
+        {
+            Id = 10,
+            Title = "Query",
+            Collection = new IdRef { Id = current.Id }
+        };
+
+        SetupLibrary(
+        [
+            queriedBookmark,
+            new Raindrop { Id = 20, Title = "Related", Collection = new IdRef { Id = matching.Id } }
+        ]);
+
+        var mockEmbeddings = new Mock<Microsoft.Extensions.AI.IEmbeddingGenerator<string, Microsoft.Extensions.AI.Embedding<float>>>();
+        mockEmbeddings
+            .Setup(generator => generator.GenerateAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<Microsoft.Extensions.AI.EmbeddingGenerationOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<string> inputs, Microsoft.Extensions.AI.EmbeddingGenerationOptions _, CancellationToken _) =>
+            {
+                var embeddings = new Microsoft.Extensions.AI.GeneratedEmbeddings<Microsoft.Extensions.AI.Embedding<float>>();
+                foreach (var input in inputs)
+                {
+                    embeddings.Add(new Microsoft.Extensions.AI.Embedding<float>(
+                        input.Contains("Query") || input.Contains("Related")
+                            ? new float[] { 1, 0 }
+                            : new float[] { 0, 1 }));
+                }
+                return embeddings;
+            });
+        var service = new CollectionSuggestionService(
+            _api.Object,
+            new CollectionSuggestionIndexCache(),
+            Options.Create(new RaindropOptions { ApiToken = Guid.NewGuid().ToString() }),
+            mockEmbeddings.Object);
+
+        var suggestions = await service.SuggestAsync(queriedBookmark, [current, matching], 2, CancellationToken.None);
+
+        Assert.Single(suggestions);
+        Assert.Equal(matching.Id, suggestions[0].Collection.Id);
+    }
 }

--- a/tests/Mcp.Tests/CollectionSuggestionServiceTests.cs
+++ b/tests/Mcp.Tests/CollectionSuggestionServiceTests.cs
@@ -230,4 +230,55 @@ public class CollectionSuggestionServiceTests
         _api.Setup(api => api.ListAsync(0, null, null, 0, 50, true, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ItemsResponse<Raindrop>(true, bookmarks));
     }
+
+    [Fact]
+    public async Task SuggestAsync_UsesSemanticScoreWhenEmbeddingGeneratorIsPresent()
+    {
+        var development = new Collection { Id = 1, Title = "Dev" };
+        var cooking = new Collection { Id = 2, Title = "Food" };
+
+        var mockEmbeddings = new Mock<Microsoft.Extensions.AI.IEmbeddingGenerator<string, Microsoft.Extensions.AI.Embedding<float>>>();
+        mockEmbeddings.Setup(g => g.GenerateAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<Microsoft.Extensions.AI.EmbeddingGenerationOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IEnumerable<string> inputs, Microsoft.Extensions.AI.EmbeddingGenerationOptions options, CancellationToken ct) =>
+            {
+                var inputList = inputs.ToList();
+                var result = new Microsoft.Extensions.AI.GeneratedEmbeddings<Microsoft.Extensions.AI.Embedding<float>>();
+                foreach(var input in inputList)
+                {
+                    // Dev match gets a vector similar to query, Food gets orthogonal
+                    if (input.Contains("Food") || input.Contains("Pasta"))
+                        result.Add(new Microsoft.Extensions.AI.Embedding<float>(new float[] { 0, 1 }));
+                    else
+                        result.Add(new Microsoft.Extensions.AI.Embedding<float>(new float[] { 1, 0 }));
+                }
+                return result;
+            });
+
+        var serviceWithEmbeddings = new CollectionSuggestionService(
+            _api.Object,
+            new CollectionSuggestionIndexCache(),
+            Options.Create(new RaindropOptions { ApiToken = Guid.NewGuid().ToString() }),
+            mockEmbeddings.Object);
+
+        SetupLibrary(
+        [
+            new Raindrop
+            {
+                Id = 10, Title = ".NET DI",
+                Collection = new IdRef { Id = development.Id }
+            },
+            new Raindrop
+            {
+                Id = 11, Title = "Pasta",
+                Collection = new IdRef { Id = cooking.Id }
+            }
+        ]);
+
+        var query = new Raindrop { Title = "C# programming" }; // completely different lexically
+
+        var suggestions = await serviceWithEmbeddings.SuggestAsync(query, [development, cooking], 3, CancellationToken.None);
+
+        Assert.Equal(development.Id, suggestions[0].Collection.Id);
+        mockEmbeddings.Verify(g => g.GenerateAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<Microsoft.Extensions.AI.EmbeddingGenerationOptions>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+    }
 }

--- a/tests/Mcp.Tests/CollectionSuggestionServiceTests.cs
+++ b/tests/Mcp.Tests/CollectionSuggestionServiceTests.cs
@@ -329,4 +329,32 @@ public class CollectionSuggestionServiceTests
         Assert.Single(suggestions);
         Assert.Equal(matching.Id, suggestions[0].Collection.Id);
     }
+
+    [Fact]
+    public async Task SuggestAsync_PropagatesCancellationFromQueryEmbeddingGeneration()
+    {
+        var collection = new Collection { Id = 1, Title = "Development" };
+        SetupLibrary([]);
+        var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+        var mockEmbeddings = new Mock<Microsoft.Extensions.AI.IEmbeddingGenerator<string, Microsoft.Extensions.AI.Embedding<float>>>();
+        mockEmbeddings
+            .Setup(generator => generator.GenerateAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<Microsoft.Extensions.AI.EmbeddingGenerationOptions>(),
+                cancellationTokenSource.Token))
+            .ThrowsAsync(new OperationCanceledException(cancellationTokenSource.Token));
+        var service = new CollectionSuggestionService(
+            _api.Object,
+            new CollectionSuggestionIndexCache(),
+            Options.Create(new RaindropOptions { ApiToken = Guid.NewGuid().ToString() }),
+            mockEmbeddings.Object);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.SuggestAsync(
+                new Raindrop { Title = "Query" },
+                [collection],
+                1,
+                cancellationTokenSource.Token));
+    }
 }


### PR DESCRIPTION
This PR implements Phase 2 of the Deterministic Collection Suggestions workflow outlined in `DETERMINISTIC_COLLECTION_SUGGESTIONS.md`.

It introduces a privacy-first, local embedding generator using `Microsoft.Extensions.AI` and the `LocalEmbeddings` package (which wraps ONNX runtime). This allows the collection suggestion algorithm to compute and blend vector semantic similarity scores with the existing Phase 1 lexical, domain, and tag signals.

### What
- Added the `LocalEmbeddings` package to the project.
- Introduced `EnableSemanticSuggestions` config option (defaults to true).
- Updated the suggestion index caching architecture to generate embeddings from a bookmark's canonical string.
- Computes and stores the mean L2-normalized vector centroid for each collection.
- Blends the Cosine Similarity score of the query vector and centroid into the final suggestion score.
- Included full graceful fallback: if the feature is disabled, if ONNX binaries fail to load, if a model download fails, or if token/memory generation fails at runtime, the code gracefully catches the exception and falls back to pure Phase 1 lexical logic.

### Why
Phase 1 collection suggestions rely strictly on exact lexical token matches, tag Jaccard overlaps, and domain mappings. While effective, it suffers from vocabulary mismatch (e.g. searching for "C# guide" when the collection contains "dotnet tutorials"). Local embeddings solve vocabulary mismatch and capture semantic intent without requiring an expensive LLM call or compromising the user's bookmark privacy by sending data to a third-party API.

### Verification
- Manually verified via test sandbox using a fallback `DummyEmbeddingGenerator`.
- Added unit tests to `CollectionSuggestionServiceTests` simulating orthogonal semantic matches.
- Verified test suite passes safely without crashing on missing ONNX native binaries.

---
*PR created automatically by Jules for task [6444327186683891206](https://jules.google.com/task/6444327186683891206) started by @g1ddy*