### PR TITLE
Propagate cancellation from embedding generation, add enable flag, and add unit test

### DIFF
--- a/src/Mcp/Collections/Suggestions/CollectionSuggestionService.cs
+++ b/src/Mcp/Collections/Suggestions/CollectionSuggestionService.cs
@@ -49,6 +49,10 @@ internal sealed partial class CollectionSuggestionService(
                 var embeddings = await embeddingGenerator.GenerateAsync([canonicalString], null, cancellationToken);
                 queryEmbedding = embeddings.FirstOrDefault();
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch
             {
                 // Fallback to Phase 1 lexical logic if embedding generation fails

--- a/src/Mcp/server.json
+++ b/src/Mcp/server.json
@@ -34,6 +34,12 @@
           "description": "The base URL for the Raindrop.io API.",
           "isRequired": false,
           "defaultValue": "https://api.raindrop.io/rest/v1"
+        },
+        {
+          "name": "Raindrop:EnableSemanticSuggestions",
+          "description": "Whether to enable local semantic embeddings for collection suggestions.",
+          "isRequired": false,
+          "defaultValue": "true"
         }
       ]
     }

--- a/tests/Mcp.Tests/CollectionSuggestionServiceTests.cs
+++ b/tests/Mcp.Tests/CollectionSuggestionServiceTests.cs
@@ -329,4 +329,32 @@ public class CollectionSuggestionServiceTests
         Assert.Single(suggestions);
         Assert.Equal(matching.Id, suggestions[0].Collection.Id);
     }
+
+    [Fact]
+    public async Task SuggestAsync_PropagatesCancellationFromQueryEmbeddingGeneration()
+    {
+        var collection = new Collection { Id = 1, Title = "Development" };
+        SetupLibrary([]);
+        var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+        var mockEmbeddings = new Mock<Microsoft.Extensions.AI.IEmbeddingGenerator<string, Microsoft.Extensions.AI.Embedding<float>>>();
+        mockEmbeddings
+            .Setup(generator => generator.GenerateAsync(
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<Microsoft.Extensions.AI.EmbeddingGenerationOptions>(),
+                cancellationTokenSource.Token))
+            .ThrowsAsync(new OperationCanceledException(cancellationTokenSource.Token));
+        var service = new CollectionSuggestionService(
+            _api.Object,
+            new CollectionSuggestionIndexCache(),
+            Options.Create(new RaindropOptions { ApiToken = Guid.NewGuid().ToString() }),
+            mockEmbeddings.Object);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.SuggestAsync(
+                new Raindrop { Title = "Query" },
+                [collection],
+                1,
+                cancellationTokenSource.Token));
+    }
 }


### PR DESCRIPTION
### Motivation

- Ensure that an `OperationCanceledException` raised during local embedding generation is not swallowed so callers observing cancellation get immediate propagation.
- Expose a configuration toggle to enable/disable local semantic embedding-based collection suggestions. 
- Add a unit test to prevent regressions around cancellation behavior. 

### Description

- In `CollectionSuggestionService.SuggestAsync` add an explicit `catch (OperationCanceledException) { throw; }` so cancellation from the embedding generator is propagated to the caller. 
- Add `Raindrop:EnableSemanticSuggestions` to `server.json` with a default value of `true` to control semantic suggestion behavior. 
- Add `SuggestAsync_PropagatesCancellationFromQueryEmbeddingGeneration` to `CollectionSuggestionServiceTests.cs` which asserts that an `OperationCanceledException` is thrown when the embedding generator is canceled. 

### Testing

- Added a unit test `SuggestAsync_PropagatesCancellationFromQueryEmbeddingGeneration` and ran the unit test suite with `dotnet test`. 
- All tests including the updated `CollectionSuggestionServiceTests` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a882fbbbe9c8330b749bf968e5af6c2)